### PR TITLE
make x11 keyboard repeat detectable

### DIFF
--- a/src/x11/ffi.rs
+++ b/src/x11/ffi.rs
@@ -1406,6 +1406,8 @@ extern "C" {
     pub fn glXMakeCurrent(dpy: *mut Display, drawable: GLXDrawable,
         ctx: GLXContext) -> Bool;
     pub fn glXSwapBuffers(dpy: *mut Display, drawable: GLXDrawable);
+
+    pub fn XkbSetDetectableAutoRepeat(dpy: *mut Display, detectable: bool, supported_rtm: *mut bool) -> bool;
 }
 
 /*

--- a/src/x11/mod.rs
+++ b/src/x11/mod.rs
@@ -179,6 +179,16 @@ impl Window {
             ic
         };
 
+        // Attempt to make keyboard input repeat detectable
+        unsafe {
+            let mut supported_ptr = false;
+            ffi::XkbSetDetectableAutoRepeat(display, true, &mut supported_ptr);
+            if !supported_ptr {
+                return Err(format!("XkbSetDetectableAutoRepeat failed"));
+            }
+        }
+
+
         // creating GL context
         let context = unsafe {
             let mut attributes = Vec::new();


### PR DESCRIPTION
By default, x11 inserts KeyRelease events for every repeated KeyPress event when you hold a key down. This makes it impossible to detect that the key is still being held down and repeated vs tapped quickly. Not so useful for game dev where you what to do something while a key is being held. This changes the behavior to repeat KeyDown events on repeat without interleaving KeyRelease events. I don't know what the behavior is on other platforms, does this need to be user-configurable?

(see http://linux.die.net/man/3/xkbsetdetectableautorepeat)
