### PR TITLE
Add `with_vsync` to WindowBuilder, plus the win32 implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub struct WindowBuilder {
     title: String,
     monitor: Option<winimpl::MonitorID>,
     gl_version: Option<(uint, uint)>,
+    vsync: bool,
 }
 
 #[cfg(feature = "window")]
@@ -84,6 +85,7 @@ impl WindowBuilder {
             title: "gl-init-rs window".to_string(),
             monitor: None,
             gl_version: None,
+            vsync: false,
         }
     }
 
@@ -116,6 +118,12 @@ impl WindowBuilder {
     ///  you would pass `(3, 3)`.
     pub fn with_gl_version(mut self, version: (uint, uint)) -> WindowBuilder {
         self.gl_version = Some(version);
+        self
+    }
+
+    /// Requests that the window has vsync enabled.
+    pub fn with_vsync(mut self) -> WindowBuilder {
+        self.vsync = true;
         self
     }
 
@@ -339,6 +347,10 @@ impl Window {
     ///
     /// You should call this function every time you have finished rendering, or the image
     ///  may not be displayed on the screen.
+    ///
+    /// **Warning**: if you enabled vsync, this function will block until the next time the screen
+    /// is refreshed. However drivers can choose to override your vsync settings, which means that
+    /// you can't know in advance whether `swap_buffers` will block or not.
     #[inline]
     pub fn swap_buffers(&self) {
         self.window.swap_buffers()

--- a/src/win32/ffi.rs
+++ b/src/win32/ffi.rs
@@ -23,7 +23,8 @@ pub mod wgl_extra {
         version: "1.0",
         generator: "struct",
         extensions: [
-            "WGL_ARB_create_context"
+            "WGL_ARB_create_context",
+            "WGL_EXT_swap_control"
         ]
     }
 }

--- a/src/win32/init.rs
+++ b/src/win32/init.rs
@@ -16,7 +16,7 @@ local_data_key!(WINDOW: (ffi::HWND, Sender<Event>))
 
 pub fn new_window(builder_dimensions: Option<(uint, uint)>, builder_title: String,
                   builder_monitor: Option<super::MonitorID>,
-                  builder_gl_version: Option<(uint, uint)>,
+                  builder_gl_version: Option<(uint, uint)>, builder_vsync: bool,
                   builder_headless: bool) -> Result<Window, String>
 {
     use std::mem;
@@ -345,6 +345,14 @@ pub fn new_window(builder_dimensions: Option<(uint, uint)>, builder_title: Strin
             }
             lib
         };
+
+        // handling vsync
+        if builder_vsync {
+            if extra_functions.SwapIntervalEXT.is_loaded() {
+                unsafe { ffi::wgl::MakeCurrent(hdc, context) };
+                extra_functions.SwapIntervalEXT(1);
+            }
+        }
 
         // building the struct
         let window = Window{

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -25,7 +25,7 @@ impl HeadlessContext {
     /// See the docs in the crate root file.
     pub fn new(builder: HeadlessRendererBuilder) -> Result<HeadlessContext, String> {
         let HeadlessRendererBuilder { dimensions, gl_version } = builder;
-        init::new_window(Some(dimensions), "".to_string(), None, gl_version, true)
+        init::new_window(Some(dimensions), "".to_string(), None, gl_version, false, true)
             .map(|w| HeadlessContext(w))
     }
 
@@ -68,8 +68,8 @@ pub struct Window {
 impl Window {
     /// See the docs in the crate root file.
     pub fn new(builder: WindowBuilder) -> Result<Window, String> {
-        let WindowBuilder { dimensions, title, monitor, gl_version } = builder;
-        init::new_window(dimensions, title, monitor, gl_version, false)
+        let WindowBuilder { dimensions, title, monitor, gl_version, vsync } = builder;
+        init::new_window(dimensions, title, monitor, gl_version, vsync, false)
     }
 }
 


### PR DESCRIPTION
Closes #61

Will open issues for X11, cocoa and android implementations.
