### PR TITLE
Only reject modes based on resolution when using fullscreen. This fixes ...

### DIFF
--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -95,7 +95,7 @@ impl Window {
                     best_mode = i;
                 }
             };
-            if best_mode == -1 {
+            if best_mode == -1 && builder.monitor.is_some() {
                 return Err(format!("Could not find a suitable graphics mode"));
             }
 


### PR DESCRIPTION
...creating a window that is not the same resolution as an existing video mode.

Close #56 
