### PR TITLE
Adds current modifiers to the mouse wheel event.

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -27,7 +27,7 @@ pub enum Event {
 
     /// A positive value indicates that the wheel was rotated forward, away from the user;
     ///  a negative value indicates that the wheel was rotated backward, toward the user.
-    MouseWheel(i32),
+    MouseWheel(i32, KeyModifiers),
 
     /// An event from the mouse has been received.
     MouseInput(ElementState, MouseButton),

--- a/src/win32/init.rs
+++ b/src/win32/init.rs
@@ -474,12 +474,12 @@ extern "stdcall" fn callback(window: ffi::HWND, msg: ffi::UINT,
         },
 
         ffi::WM_MOUSEWHEEL => {
-            use events::MouseWheel;
+            use events::{KeyModifiers, MouseWheel};
 
             let value = (wparam >> 16) as i16;
             let value = value as i32;
 
-            send_event(window, MouseWheel(value));
+            send_event(window, MouseWheel(value, KeyModifiers::empty()));
 
             0
         },

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -455,11 +455,11 @@ impl Window {
                         ffi::Button2 => Some(MiddleMouseButton),
                         ffi::Button3 => Some(RightMouseButton),
                         ffi::Button4 => {
-                            events.push(MouseWheel(1));
+                            events.push(MouseWheel(1, self.current_modifiers.get()));
                             None
                         }
                         ffi::Button5 => {
-                            events.push(MouseWheel(-1));
+                            events.push(MouseWheel(-1, self.current_modifiers.get()));
                             None
                         }
                         _ => None


### PR DESCRIPTION
I'm not sure if this is a great API. But we need access to the key modifiers to determine how to interpret a mouse wheel event.

If you would prefer a different method (maybe a modifiers accessor on window?) let me know and I'll update the PR.
