### PR TITLE
Remove call to glFlush() before swap_buffers on win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ fn main() {
 
 ### Win32
 
+ - You must call `glFlush` before `swap_buffers`, or else on Windows 8 nothing will be visible on the window
  - Pixel formats are not implemented
  - If you don't have MinGW installed, you will need to provide `libgdi32.a` and `libopengl32.a` ; you can put them in `C:\Users\you\.rust`
  - If you don't have `make` in your PATH, you can pass `--no-default-features --features "window"` when compiling ([see also](http://crates.io/manifest.html#the-[features]-section))

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -57,6 +57,8 @@ impl Context {
         self.gl.Color3f(0.0, 0.0, 1.0);
         self.gl.Vertex2f(0.5, -0.5);
         self.gl.End();
+
+        self.gl.Flush();
     }
 
     #[cfg(target_os = "android")]
@@ -78,6 +80,8 @@ impl Context {
         self.gl.DrawArrays(gl::TRIANGLES, 0, 3);
         self.gl.DisableClientState(gl::VERTEX_ARRAY);
         self.gl.DisableClientState(gl::COLOR_ARRAY);
+        
+        self.gl.Flush();
     }
 }
 

--- a/src/win32/ffi.rs
+++ b/src/win32/ffi.rs
@@ -720,9 +720,6 @@ extern "system" {
     // http://msdn.microsoft.com/en-us/library/windows/desktop/ms633519(v=vs.85).aspx
     pub fn GetWindowRect(hWnd: HWND, lpRect: *mut RECT) -> BOOL;
 
-    //
-    pub fn glFlush();
-
     // http://msdn.microsoft.com/en-us/library/windows/desktop/ms684175(v=vs.85).aspx
     pub fn LoadLibraryW(lpFileName: LPCWSTR) -> HMODULE;
 

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -228,9 +228,6 @@ impl Window {
     /// See the docs in the crate root file.
     pub fn swap_buffers(&self) {
         unsafe {
-            // calling glFlush is necessary on Windows 8
-            ffi::glFlush();
-
             ffi::SwapBuffers(self.hdc);
         }
     }


### PR DESCRIPTION
We may want not to call `swap_buffers` in the same thread as the
current thread, so we're moving the call to `glFlush` out of the scope
of glutin.
