### PR TITLE
Implement lists sharing

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -39,8 +39,12 @@ impl MonitorID {
 }
 
 impl Window {
-    pub fn new(_builder: WindowBuilder) -> Result<Window, CreationError> {
+    pub fn new(builder: WindowBuilder) -> Result<Window, CreationError> {
         use std::{mem, ptr};
+
+        if builder.sharing.is_some() {
+            unimplemented!()
+        }
 
         let native_window = unsafe { android_glue::get_native_window() };
         if native_window.is_null() {

--- a/src/osx/mod.rs
+++ b/src/osx/mod.rs
@@ -71,6 +71,10 @@ impl Deref<Window> for HeadlessContext {
 #[cfg(feature = "window")]
 impl Window {
     pub fn new(builder: WindowBuilder) -> Result<Window, CreationError> {
+        if builder.sharing.is_some() {
+            unimplemented!()
+        }
+
         Window::new_impl(builder.dimensions, builder.title.as_slice(), builder.monitor, true)
     }
 }

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -25,8 +25,9 @@ impl HeadlessContext {
     /// See the docs in the crate root file.
     pub fn new(builder: HeadlessRendererBuilder) -> Result<HeadlessContext, CreationError> {
         let HeadlessRendererBuilder { dimensions, gl_version, gl_debug } = builder;
-        init::new_window(Some(dimensions), "".to_string(), None, gl_version, gl_debug, false, true)
-            .map(|w| HeadlessContext(w))
+        init::new_window(Some(dimensions), "".to_string(), None, gl_version, gl_debug, false, true,
+                         None)
+                         .map(|w| HeadlessContext(w))
     }
 
     /// See the docs in the crate root file.
@@ -69,8 +70,9 @@ impl Window {
     /// See the docs in the crate root file.
     pub fn new(builder: WindowBuilder) -> Result<Window, CreationError> {
         let WindowBuilder { dimensions, title, monitor, gl_version,
-                            gl_debug, vsync, visible } = builder;
-        init::new_window(dimensions, title, monitor, gl_version, gl_debug, vsync, !visible)
+                            gl_debug, vsync, visible, sharing } = builder;
+        init::new_window(dimensions, title, monitor, gl_version, gl_debug, vsync,
+                         !visible, sharing.map(|w| w.window.context))
     }
 }
 

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -248,11 +248,17 @@ impl Window {
                 })
             });
 
+            let share = if let Some(win) = builder.sharing {
+                win.window.context
+            } else {
+                ptr::null()
+            };
+
             let context = if extra_functions.CreateContextAttribsARB.is_loaded() {
                 extra_functions.CreateContextAttribsARB(display as *mut ffi::glx_extra::types::Display,
-                    fb_config, ptr::null(), 1, attributes.as_ptr())
+                    fb_config, share, 1, attributes.as_ptr())
             } else {
-                ffi::glx::CreateContext(display, &mut visual_infos, ptr::null(), 1)
+                ffi::glx::CreateContext(display, &mut visual_infos, share, 1)
             };
 
             if context.is_null() {


### PR DESCRIPTION
Adds `with_shared_lists()` to `WindowBuilder`.
Cocoa and Android call `unimplemented!()` if this is used (this is better than ignoring).
