### PR TITLE
Change the way that event iterators are represented.

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -7,6 +7,8 @@ use events::ElementState::{Pressed, Released};
 use events::Event::{MouseInput, MouseMoved};
 use events::MouseButton::LeftMouseButton;
 
+use std::collections::RingBuf;
+
 use BuilderAttribs;
 
 pub struct Window {
@@ -20,8 +22,10 @@ pub struct MonitorID;
 
 mod ffi;
 
-pub fn get_available_monitors() -> Vec<MonitorID> {
-    vec![ MonitorID ]
+pub fn get_available_monitors() -> RingBuf <MonitorID> {
+    let rb = RingBuf::new();
+    rb.push_back(MonitorId);
+    rb
 }
 
 pub fn get_primary_monitor() -> MonitorID {
@@ -215,19 +219,19 @@ impl Window {
         WindowProxy
     }
 
-    pub fn poll_events(&self) -> Vec<Event> {
-        let mut events = Vec::new();
+    pub fn poll_events(&self) -> RingBuf<Event> {
+        let mut events = RingBuf::new();
         loop {
             match self.event_rx.try_recv() {
                 Ok(event) => match event {
                     android_glue::Event::EventDown => {
-                        events.push(MouseInput(Pressed, LeftMouseButton));
+                        events.push_back(MouseInput(Pressed, LeftMouseButton));
                     },
                     android_glue::Event::EventUp => {
-                        events.push(MouseInput(Released, LeftMouseButton));
+                        events.push_back(MouseInput(Released, LeftMouseButton));
                     },
                     android_glue::Event::EventMove(x, y) => {
-                        events.push(MouseMoved((x as int, y as int)));
+                        events.push_back(MouseMoved((x as int, y as int)));
                     },
                 },
                 Err(_) => {
@@ -238,7 +242,7 @@ impl Window {
         events
     }
 
-    pub fn wait_events(&self) -> Vec<Event> {
+    pub fn wait_events(&self) -> RingBuf<Event> {
         use std::time::Duration;
         use std::io::timer;
         timer::sleep(Duration::milliseconds(16));

--- a/src/osx/monitor.rs
+++ b/src/osx/monitor.rs
@@ -1,9 +1,10 @@
 use core_graphics::display;
+use std::collections::RingBuf;
 
 pub struct MonitorID(u32);
 
 pub fn get_available_monitors() -> Vec<MonitorID> {
-    let mut monitors = Vec::new();
+    let mut monitors = RingBuf::new();
     unsafe {
         let max_displays = 10u32;
         let mut active_displays = [0u32, ..10];
@@ -12,7 +13,7 @@ pub fn get_available_monitors() -> Vec<MonitorID> {
                                                         &mut active_displays[0],
                                                         &mut display_count);
         for i in range(0u, display_count as uint) {
-            monitors.push(MonitorID(active_displays[i]));
+            monitors.push_back(MonitorID(active_displays[i]));
         }
     }
     monitors

--- a/src/win32/monitor.rs
+++ b/src/win32/monitor.rs
@@ -1,5 +1,7 @@
 use winapi;
 
+use std::collections::RingBuf;
+
 /// Win32 implementation of the main `MonitorID` object.
 pub struct MonitorID {
     /// The system name of the monitor.
@@ -22,11 +24,11 @@ pub struct MonitorID {
 }
 
 /// Win32 implementation of the main `get_available_monitors` function.
-pub fn get_available_monitors() -> Vec<MonitorID> {
+pub fn get_available_monitors() -> RingBuf<MonitorID> {
     use std::{iter, mem, ptr};
 
     // return value
-    let mut result = Vec::new();
+    let mut result = RingBuf::new();
 
     // enumerating the devices is done by querying device 0, then device 1, then device 2, etc.
     //  until the query function returns null
@@ -78,7 +80,7 @@ pub fn get_available_monitors() -> Vec<MonitorID> {
         };
 
         // adding to the resulting list
-        result.push(MonitorID {
+        result.push_back(MonitorID {
             name: output.DeviceName,
             readable_name: readable_name,
             flags: output.StateFlags,
@@ -123,7 +125,7 @@ impl MonitorID {
     }
 
     /// This is a Win32-only function for `MonitorID` that returns the position of the
-    ///  monitor on the desktop. 
+    ///  monitor on the desktop.
     /// A window that is positionned at these coordinates will overlap the monitor.
     pub fn get_position(&self) -> (uint, uint) {
         self.position

--- a/src/x11/window/monitor.rs
+++ b/src/x11/window/monitor.rs
@@ -1,10 +1,11 @@
-use std::{ptr};
+use std::ptr;
+use std::collections::RingBuf;
 use super::super::ffi;
 use super::ensure_thread_init;
 
 pub struct MonitorID(pub uint);
 
-pub fn get_available_monitors() -> Vec<MonitorID> {
+pub fn get_available_monitors() -> RingBuf<MonitorID> {
     ensure_thread_init();
     let nb_monitors = unsafe {
         let display = ffi::XOpenDisplay(ptr::null());
@@ -16,9 +17,9 @@ pub fn get_available_monitors() -> Vec<MonitorID> {
         nb_monitors
     };
 
-    let mut vec = Vec::new();
-    vec.grow_fn(nb_monitors as uint, |i| MonitorID(i));
-    vec
+    let mut monitors = RingBuf::new();
+    monitors.extend(range(0, nb_monitors).map(|i| MonitorID(i as uint)));
+    monitors
 }
 
 pub fn get_primary_monitor() -> MonitorID {


### PR DESCRIPTION
The bulk of this commit is changing instances of Vec to RingBuf which is
optimized for the push_back() / pop_front() strategy that is used
internaly in the event system.

The glutin custom iterators are now just wrappers around the RingBuf
iterator type.  This will bring the running time of iterator traversal from
O(n^2) to O(n) because shifting-on-delete won't be performed.