### PR TITLE
Depend on git sources of upstream gl, for this git sourced version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ window = []
 headless = []
 
 [dependencies.gl_common]
-gl_common = "*"
+git = "https://github.com/bjz/gl-rs"
 
-[build-dependencies]
-gl_generator = "*"
+[build-dependencies.gl_generator]
+git = "https://github.com/bjz/gl-rs"
 
 [target.arm-linux-androideabi.dependencies.android_glue]
 git = "https://github.com/tomaka/android-rs-glue"


### PR DESCRIPTION
...of glutin:

When packaging, the upstreams can be cargo.io upstreams, but where development is rapid, they probably should remain git upstreams.

Pre rust-1.0, this probably isn't a critical distinction, because rust itself is pushing the breaking changes.  But once rust settles, cargo pacakges will be longer term and depend on other older stable cargo packages, and git code will need to keep up with it's dependencies a bit faster.

... even if I'm wrong about that, this change was necessary for me today to get glutin to compile, because gl-rs on cargo.io is out of date, but it's git sources are fine.