### PR TITLE
OSX compatibility for Rust 1.0 alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,19 @@ git = "https://github.com/servo/rust-cocoa"
 
 [target.x86_64-apple-darwin.dependencies.cocoa]
 git = "https://github.com/servo/rust-cocoa"
+features = ["arch_64"]
 
 [target.i686-apple-darwin.dependencies.core_graphics]
 git = "https://github.com/servo/rust-core-graphics"
 
 [target.x86_64-apple-darwin.dependencies.core_graphics]
 git = "https://github.com/servo/rust-core-graphics"
+
+[target.i686-apple-darwin.dependencies.core_foundation]
+git = "https://github.com/servo/rust-core-foundation"
+
+[target.x86_64-apple-darwin.dependencies.core_foundation]
+git = "https://github.com/servo/rust-core-foundation"
 
 [target.i686-pc-windows-gnu.dependencies.winapi]
 version = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ git = "https://github.com/servo/rust-cocoa"
 
 [target.x86_64-apple-darwin.dependencies.cocoa]
 git = "https://github.com/servo/rust-cocoa"
-features = ["arch_64"]
 
 [target.i686-apple-darwin.dependencies.core_graphics]
 git = "https://github.com/servo/rust-core-graphics"

--- a/src/osx/monitor.rs
+++ b/src/osx/monitor.rs
@@ -3,11 +3,11 @@ use std::collections::RingBuf;
 
 pub struct MonitorID(u32);
 
-pub fn get_available_monitors() -> Vec<MonitorID> {
+pub fn get_available_monitors() -> RingBuf<MonitorID> {
     let mut monitors = RingBuf::new();
     unsafe {
         let max_displays = 10u32;
-        let mut active_displays = [0u32, ..10];
+        let mut active_displays = [0u32; 10];
         let mut display_count = 0;
         display::CGGetActiveDisplayList(max_displays,
                                                         &mut active_displays[0],


### PR DESCRIPTION
This is a work in progress because it depends on a few pending PR's to work:
* servo/rust-cocoa#53 -- Rust 1.0 alpha for Cocoa bindings (required)
* servo/rust-core-foundation#50 -- Rust 1.0 alpha for Core Foundation bindings (required)