### PR TITLE
Add mouse cursor support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "glutin"
-version = "0.0.4-pre"
+version = "0.0.5-pre"
 authors = ["tomaka <pierre.krieger1708@gmail.com>"]
 description = "Cross-plaform OpenGL context provider. Important: the crates.io only supports Windows and Linux for the moment."
 keywords = ["windowing", "opengl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "glutin"
-version = "0.0.5-pre"
+version = "0.0.4-pre"
 authors = ["tomaka <pierre.krieger1708@gmail.com>"]
 description = "Cross-plaform OpenGL context provider. Important: the crates.io only supports Windows and Linux for the moment."
 keywords = ["windowing", "opengl"]

--- a/README.md
+++ b/README.md
@@ -58,14 +58,16 @@ fn main() {
  - Some events are not implemented
  - Implementation is still work-in-progress
  - Vsync not implemented
-
+ - Changing the cursor (set_cursor) is not implemented 
 ### Win32
 
  - You must call `glFlush` before `swap_buffers`, or else on Windows 8 nothing will be visible on the window
  - Pixel formats are not implemented
+ - Changing the cursor (set_cursor) is not implemented
 
 ### X11
 
  - Some input events are not implemented
  - Pixel formats not implemented
  - Vsync not implemented
+ - Not all mouse cursors are implemented (ContextMenu, ...)

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,0 +1,49 @@
+#[cfg(target_os = "android")]
+#[macro_use]
+extern crate android_glue;
+
+extern crate glutin;
+
+use glutin::{Event, ElementState, MouseCursor};
+
+mod support;
+
+#[cfg(target_os = "android")]
+android_start!(main);
+
+#[cfg(not(feature = "window"))]
+fn main() { println!("This example requires glutin to be compiled with the `window` feature"); }
+
+#[cfg(feature = "window")]
+fn main() {
+    
+    let mut window = glutin::Window::new().unwrap();
+    window.set_title("A fantastic window!");   
+    unsafe { window.make_current() };
+
+    let context = support::load(&window);
+    let cursors = [MouseCursor::Default, MouseCursor::Crosshair, MouseCursor::Hand, MouseCursor::Arrow, MouseCursor::Move, MouseCursor::Text, MouseCursor::Wait, MouseCursor::Help, MouseCursor::Progress, MouseCursor::NotAllowed, MouseCursor::ContextMenu, MouseCursor::NoneCursor, MouseCursor::Cell, MouseCursor::VerticalText, MouseCursor::Alias, MouseCursor::Copy, MouseCursor::NoDrop, MouseCursor::Grab, MouseCursor::Grabbing, MouseCursor::AllScroll, MouseCursor::ZoomIn, MouseCursor::ZoomOut, MouseCursor::EResize, MouseCursor::NResize, MouseCursor::NeResize, MouseCursor::NwResize, MouseCursor::SResize, MouseCursor::SeResize, MouseCursor::SwResize, MouseCursor::WResize, MouseCursor::EwResize, MouseCursor::NsResize, MouseCursor::NeswResize, MouseCursor::NwseResize, MouseCursor::ColResize, MouseCursor::RowResize];
+    let mut cursor_idx = 0;
+    
+    while !window.is_closed() {
+        context.draw_frame((0.0, 1.0, 0.0, 1.0));
+        window.swap_buffers();
+
+        for event in window.wait_events() {
+            match event {
+                Event::KeyboardInput(ElementState::Pressed, _, _) => {
+                    println!("Setting cursor to \"{:?}\"", cursors[cursor_idx]);
+                    window.set_cursor(cursors[cursor_idx]);
+                    if cursor_idx < cursors.len() - 1 {
+                        cursor_idx += 1;
+                    } else {
+                        cursor_idx = 0;
+                    }
+                },
+                _ => (),
+            }
+            
+        }
+        
+    }
+}

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -280,6 +280,9 @@ impl Window {
 
     pub fn set_window_resize_callback(&mut self, _: Option<fn(uint, uint)>) {
     }
+
+    pub fn set_cursor(&self, cursor: MouseCursor) {
+    }
 }
 
 unsafe impl Send for Window {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,62 @@ pub enum Api {
     OpenGlEs,
 }
 
+#[derive(Show, Copy)]
+pub enum MouseCursor {
+    /// The platform-dependent default cursor.
+    Default,
+    /// A simple crosshair.
+    Crosshair,
+    /// A hand (often used to indicate links in web browsers).
+    Hand,
+    /// Self explanatory.
+    Arrow,
+    /// Indicates something is to be moved.
+    Move,
+    /// Indicates text that may be selected or edited.
+    Text,
+    /// Program busy indicator.
+    Wait,
+    /// Help indicator (often rendered as a "?")
+    Help,
+    /// Progress indicator. Shows that processing is being done. But in contrast
+    /// with "Wait" the user may still interact with the program. Often rendered
+    /// as a spinning beach ball, or an arrow with a watch or hourglass. 
+    Progress,
+
+    /// Cursor showing that something cannot be done.
+    NotAllowed,
+    ContextMenu,
+    NoneCursor,
+    Cell,
+    VerticalText,
+    Alias,
+    Copy,
+    NoDrop,
+    Grab,
+    Grabbing,
+    AllScroll,
+    ZoomIn,
+    ZoomOut,
+
+    /// Indicate that some edge is to be moved. For example, the 'SeResize' cursor
+    /// is used when the movement starts from the south-east corner of the box.
+    EResize,
+    NResize,
+    NeResize,
+    NwResize,
+    SResize,
+    SeResize,
+    SwResize,
+    WResize,
+    EwResize,
+    NsResize,
+    NeswResize,
+    NwseResize,
+    ColResize,
+    RowResize,
+}
+
 /// Object that allows you to build windows.
 #[cfg(feature = "window")]
 pub struct WindowBuilder<'a> {
@@ -558,6 +614,11 @@ impl Window {
     #[experimental]
     pub fn set_window_resize_callback(&mut self, callback: Option<fn(uint, uint)>) {
         self.window.set_window_resize_callback(callback);
+    }
+
+    /// Modifies the mouse cursor of the window.
+    pub fn set_cursor(&mut self, cursor: MouseCursor) {
+        self.window.set_cursor(cursor);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,6 +617,7 @@ impl Window {
     }
 
     /// Modifies the mouse cursor of the window.
+    /// Has no effect on Android.
     pub fn set_cursor(&mut self, cursor: MouseCursor) {
         self.window.set_cursor(cursor);
     }

--- a/src/osx/mod.rs
+++ b/src/osx/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "headless")]
 pub use self::headless::HeadlessContext;
 
-use {CreationError, Event};
+use {CreationError, Event, MouseCursor};
 use CreationError::OsError;
 use libc;
 

--- a/src/osx/mod.rs
+++ b/src/osx/mod.rs
@@ -491,4 +491,8 @@ impl Window {
     pub fn set_window_resize_callback(&mut self, callback: Option<fn(uint, uint)>) {
         self.resize = callback;
     }
+
+    pub fn set_cursor(&self, cursor: MouseCursor) {
+        unimplemented!()
+    }
 }

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -285,6 +285,10 @@ impl Window {
 
     pub fn set_window_resize_callback(&mut self, _: Option<fn(uint, uint)>) {
     }
+
+    pub fn set_cursor(&self, cursor: MouseCursor) {
+        unimplemented!()
+    }
 }
 
 #[unsafe_destructor]

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -4,7 +4,7 @@ use std::ffi::CString;
 use std::collections::RingBuf;
 use std::sync::mpsc::Receiver;
 use libc;
-use {CreationError, Event};
+use {CreationError, Event, MouseCursor};
 
 use BuilderAttribs;
 

--- a/src/x11/ffi.rs
+++ b/src/x11/ffi.rs
@@ -1384,6 +1384,7 @@ extern "C" {
 #[link(name = "GL")]
 #[link(name = "X11")]
 #[link(name = "Xxf86vm")]
+#[link(name = "Xcursor")]
 extern "C" {
     pub fn XCloseDisplay(display: *mut Display);
     pub fn XCheckMaskEvent(display: *mut Display, event_mask: libc::c_long,
@@ -1454,6 +1455,9 @@ extern "C" {
         x: libc::c_int, y: libc::c_int) -> Bool;
     pub fn XF86VidModeGetAllModeLines(dpy: *mut Display, screen: libc::c_int,
         modecount_return: *mut libc::c_int, modesinfo: *mut *mut *mut XF86VidModeModeInfo) -> Bool;
+
+    pub fn XcursorLibraryLoadCursor(dpy: *mut Display, name: *const libc::c_char) -> Cursor;
+    pub fn XDefineCursor(dby: *mut Display, w: Window, cursor: Cursor);
 }
 
 /*

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -1,4 +1,4 @@
-use {Event, BuilderAttribs};
+use {Event, BuilderAttribs, MouseCursor};
 use CreationError;
 use CreationError::OsError;
 use libc;
@@ -610,5 +610,49 @@ impl Window {
     }
 
     pub fn set_window_resize_callback(&mut self, _: Option<fn(uint, uint)>) {
+    }
+
+    pub fn set_cursor(&self, cursor: MouseCursor) {
+        unsafe {
+            use std::ffi::CString;
+            let cursor_name = match cursor {
+                MouseCursor::Default => "left_ptr",
+                MouseCursor::Crosshair => "crosshair",
+                MouseCursor::Hand => "hand",
+                MouseCursor::Arrow => "arrow",
+                MouseCursor::Move => "fleur",
+                MouseCursor::Text => "xterm",
+                MouseCursor::Wait => "watch",
+                MouseCursor::Help => "question_arrow",
+                MouseCursor::Progress => "watch", // TODO: Find better matching X11 cursor
+                MouseCursor::EResize => "right_side",
+                MouseCursor::NResize => "top_side",
+                MouseCursor::NeResize => "top_right_corner",
+                MouseCursor::NwResize => "top_left_corner",
+                MouseCursor::SResize => "bottom_side",
+                MouseCursor::SeResize => "bottom_right_corner",
+                MouseCursor::SwResize => "bottom_left_corner",
+                MouseCursor::WResize => "left_side",
+                MouseCursor::EwResize => "h_double_arrow",
+                MouseCursor::NsResize => "v_double_arrow",
+
+                
+                MouseCursor::NeswResize | MouseCursor::NwseResize => "sizing", // TODO: Better matching X11 cursor
+                
+                MouseCursor::ColResize | MouseCursor::RowResize => "double_arrow", // TODO: Better matching X11 cursor
+
+                /// TODO: Find matching X11 cursors
+                MouseCursor::NotAllowed | MouseCursor::ContextMenu |
+                MouseCursor::NoneCursor | MouseCursor::Cell |
+                MouseCursor::VerticalText | MouseCursor::Alias |
+                MouseCursor::Copy | MouseCursor::NoDrop | MouseCursor::Grab |
+                MouseCursor::Grabbing | MouseCursor::AllScroll |
+                MouseCursor::ZoomIn | MouseCursor::ZoomOut => "left_ptr",
+            };
+            let c_string = CString::from_slice(cursor_name.as_bytes());
+            let xcursor = ffi::XcursorLibraryLoadCursor(self.x.display, c_string.as_ptr());
+            ffi::XDefineCursor (self.x.display, self.x.window, xcursor);
+            ffi::XFlush(self.x.display);
+        }
     }
 }

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -616,15 +616,21 @@ impl Window {
         unsafe {
             use std::ffi::CString;
             let cursor_name = match cursor {
-                MouseCursor::Default => "left_ptr",
-                MouseCursor::Crosshair => "crosshair",
-                MouseCursor::Hand => "hand",
+                MouseCursor::Alias => "link",
                 MouseCursor::Arrow => "arrow",
-                MouseCursor::Move => "fleur",
-                MouseCursor::Text => "xterm",
-                MouseCursor::Wait => "watch",
+                MouseCursor::Cell => "plus",
+                MouseCursor::Copy => "copy",
+                MouseCursor::Crosshair => "crosshair",
+                MouseCursor::Default => "left_ptr",
+                MouseCursor::Grabbing => "grabbing",
+                MouseCursor::Hand | MouseCursor::Grab => "hand",
                 MouseCursor::Help => "question_arrow",
-                MouseCursor::Progress => "watch", // TODO: Find better matching X11 cursor
+                MouseCursor::Move => "move",
+                MouseCursor::NoDrop => "circle",
+                MouseCursor::NotAllowed => "crossed_circle",
+                MouseCursor::Progress => "left_ptr_watch",
+
+                /// Resize cursors
                 MouseCursor::EResize => "right_side",
                 MouseCursor::NResize => "top_side",
                 MouseCursor::NeResize => "top_right_corner",
@@ -633,21 +639,18 @@ impl Window {
                 MouseCursor::SeResize => "bottom_right_corner",
                 MouseCursor::SwResize => "bottom_left_corner",
                 MouseCursor::WResize => "left_side",
-                MouseCursor::EwResize => "h_double_arrow",
-                MouseCursor::NsResize => "v_double_arrow",
+                MouseCursor::EwResize | MouseCursor::ColResize => "h_double_arrow",
+                MouseCursor::NsResize | MouseCursor::RowResize => "v_double_arrow",
+                MouseCursor::NwseResize => "bd_double_arrow",
+                MouseCursor::NeswResize => "fd_double_arrow",
 
+                MouseCursor::Text | MouseCursor::VerticalText => "xterm",
+                MouseCursor::Wait => "watch",
                 
-                MouseCursor::NeswResize | MouseCursor::NwseResize => "sizing", // TODO: Better matching X11 cursor
-                
-                MouseCursor::ColResize | MouseCursor::RowResize => "double_arrow", // TODO: Better matching X11 cursor
-
                 /// TODO: Find matching X11 cursors
-                MouseCursor::NotAllowed | MouseCursor::ContextMenu |
-                MouseCursor::NoneCursor | MouseCursor::Cell |
-                MouseCursor::VerticalText | MouseCursor::Alias |
-                MouseCursor::Copy | MouseCursor::NoDrop | MouseCursor::Grab |
-                MouseCursor::Grabbing | MouseCursor::AllScroll |
-                MouseCursor::ZoomIn | MouseCursor::ZoomOut => "left_ptr",
+                MouseCursor::ContextMenu | MouseCursor::NoneCursor |
+                MouseCursor::AllScroll | MouseCursor::ZoomIn |
+                MouseCursor::ZoomOut => "left_ptr",
             };
             let c_string = CString::from_slice(cursor_name.as_bytes());
             let xcursor = ffi::XcursorLibraryLoadCursor(self.x.display, c_string.as_ptr());


### PR DESCRIPTION
Add a new api, window.set_cursor, for setting the cursor. The enum MouseCursor lists the possible cursors.

Only X11 is implemented. On OSX, Android, & Win32 the window.set_cursor function
either does nothing or calls the "unimplemented!" macro.