### PR TITLE
Change uint/int to usize/isize

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,10 +1,10 @@
 #[derive(Clone, Show, Copy)]
 pub enum Event {
     /// The size of the window has changed.
-    Resized(uint, uint),
+    Resized(usize, usize),
 
     /// The position of the window has changed.
-    Moved(int, int),
+    Moved(isize, isize),
 
     /// The window has been closed.
     Closed,
@@ -23,7 +23,7 @@ pub enum Event {
     /// The cursor has moved on the window.
     ///
     /// The parameter are the (x,y) coords in pixels relative to the top-left corner of the window.
-    MouseMoved((int, int)),
+    MouseMoved((isize, isize)),
 
     /// A positive value indicates that the wheel was rotated forward, away from the user;
     ///  a negative value indicates that the wheel was rotated backward, toward the user.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,10 @@ struct BuilderAttribs<'a> {
     headless: bool,
     strict: bool,
     sharing: Option<&'a winimpl::Window>,
-    dimensions: Option<(uint, uint)>,
+    dimensions: Option<(usize, usize)>,
     title: String,
     monitor: Option<winimpl::MonitorID>,
-    gl_version: Option<(uint, uint)>,
+    gl_version: Option<(usize, usize)>,
     gl_debug: bool,
     vsync: bool,
     visible: bool,
@@ -151,7 +151,7 @@ impl<'a> WindowBuilder<'a> {
     /// Requests the window to be of specific dimensions.
     ///
     /// Width and height are in pixels.
-    pub fn with_dimensions(mut self, width: uint, height: uint) -> WindowBuilder<'a> {
+    pub fn with_dimensions(mut self, width: usize, height: usize) -> WindowBuilder<'a> {
         self.attribs.dimensions = Some((width, height));
         self
     }
@@ -183,7 +183,7 @@ impl<'a> WindowBuilder<'a> {
     ///
     /// Version is a (major, minor) pair. For example to request OpenGL 3.3
     ///  you would pass `(3, 3)`.
-    pub fn with_gl_version(mut self, version: (uint, uint)) -> WindowBuilder<'a> {
+    pub fn with_gl_version(mut self, version: (usize, usize)) -> WindowBuilder<'a> {
         self.attribs.gl_version = Some(version);
         self
     }
@@ -284,7 +284,7 @@ pub struct HeadlessRendererBuilder {
 #[cfg(feature = "headless")]
 impl HeadlessRendererBuilder {
     /// Initializes a new `HeadlessRendererBuilder` with default values.
-    pub fn new(width: uint, height: uint) -> HeadlessRendererBuilder {
+    pub fn new(width: usize, height: usize) -> HeadlessRendererBuilder {
         HeadlessRendererBuilder {
             attribs: BuilderAttribs {
                 headless: true,
@@ -298,7 +298,7 @@ impl HeadlessRendererBuilder {
     ///
     /// Version is a (major, minor) pair. For example to request OpenGL 3.3
     ///  you would pass `(3, 3)`.
-    pub fn with_gl_version(mut self, version: (uint, uint)) -> HeadlessRendererBuilder {
+    pub fn with_gl_version(mut self, version: (usize, usize)) -> HeadlessRendererBuilder {
         self.attribs.gl_version = Some(version);
         self
     }
@@ -434,7 +434,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_position(&self) -> Option<(int, int)> {
+    pub fn get_position(&self) -> Option<(isize, isize)> {
         self.window.get_position()
     }
 
@@ -444,7 +444,7 @@ impl Window {
     ///
     /// This is a no-op if the window has already been closed.
     #[inline]
-    pub fn set_position(&self, x: int, y: int) {
+    pub fn set_position(&self, x: isize, y: isize) {
         self.window.set_position(x, y)
     }
 
@@ -456,7 +456,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(uint, uint)> {
+    pub fn get_inner_size(&self) -> Option<(usize, usize)> {
         self.window.get_inner_size()
     }
 
@@ -467,7 +467,7 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_outer_size(&self) -> Option<(uint, uint)> {
+    pub fn get_outer_size(&self) -> Option<(usize, usize)> {
         self.window.get_outer_size()
     }
 
@@ -477,7 +477,7 @@ impl Window {
     ///
     /// This is a no-op if the window has already been closed.
     #[inline]
-    pub fn set_inner_size(&self, x: uint, y: uint) {
+    pub fn set_inner_size(&self, x: usize, y: usize) {
         self.window.set_inner_size(x, y)
     }
 
@@ -556,7 +556,7 @@ impl Window {
     /// operating systems) during resize operations. This can be used to repaint
     /// during window resizing.
     #[experimental]
-    pub fn set_window_resize_callback(&mut self, callback: Option<fn(uint, uint)>) {
+    pub fn set_window_resize_callback(&mut self, callback: Option<fn(usize, usize)>) {
         self.window.set_window_resize_callback(callback);
     }
 }
@@ -621,7 +621,7 @@ impl HeadlessContext {
     }
 
     #[experimental]
-    pub fn set_window_resize_callback(&mut self, _: Option<fn(uint, uint)>) {
+    pub fn set_window_resize_callback(&mut self, _: Option<fn(usize, usize)>) {
     }
 }
 
@@ -698,7 +698,7 @@ impl MonitorID {
     }
 
     /// Returns the number of pixels currently displayed on the monitor.
-    pub fn get_dimensions(&self) -> (uint, uint) {
+    pub fn get_dimensions(&self) -> (usize, usize) {
         let &MonitorID(ref id) = self;
         id.get_dimensions()
     }

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -160,7 +160,7 @@ impl Window {
             }
 
             for i in range(0, mode_num) {
-                let mode: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as int) as *const _);
+                let mode: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as isize) as *const _);
                 if mode.hdisplay == dimensions.0 as u16 && mode.vdisplay == dimensions.1 as u16 {
                     best_mode = i;
                 }
@@ -215,7 +215,7 @@ impl Window {
         if builder.monitor.is_some() {
             window_attributes |= ffi::CWOverrideRedirect;
             unsafe {
-                ffi::XF86VidModeSwitchToMode(display, screen_id, *modes.offset(best_mode as int));
+                ffi::XF86VidModeSwitchToMode(display, screen_id, *modes.offset(best_mode as isize));
                 ffi::XF86VidModeSetViewPort(display, screen_id, 0, 0);
                 set_win_attr.override_redirect = 1;
             }
@@ -383,7 +383,7 @@ impl Window {
         }
     }
 
-    fn get_geometry(&self) -> Option<(int, int, uint, uint)> {
+    fn get_geometry(&self) -> Option<(isize, isize, usize, usize)> {
         unsafe {
             use std::mem;
 
@@ -402,27 +402,27 @@ impl Window {
                 return None;
             }
 
-            Some((x as int, y as int, width as uint, height as uint))
+            Some((x as isize, y as isize, width as usize, height as usize))
         }
     }
 
-    pub fn get_position(&self) -> Option<(int, int)> {
+    pub fn get_position(&self) -> Option<(isize, isize)> {
         self.get_geometry().map(|(x, y, _, _)| (x, y))
     }
 
-    pub fn set_position(&self, x: int, y: int) {
+    pub fn set_position(&self, x: isize, y: isize) {
         unsafe { ffi::XMoveWindow(self.x.display, self.x.window, x as libc::c_int, y as libc::c_int) }
     }
 
-    pub fn get_inner_size(&self) -> Option<(uint, uint)> {
+    pub fn get_inner_size(&self) -> Option<(usize, usize)> {
         self.get_geometry().map(|(_, _, w, h)| (w, h))
     }
 
-    pub fn get_outer_size(&self) -> Option<(uint, uint)> {
+    pub fn get_outer_size(&self) -> Option<(usize, usize)> {
         unimplemented!()
     }
 
-    pub fn set_inner_size(&self, _x: uint, _y: uint) {
+    pub fn set_inner_size(&self, _x: usize, _y: usize) {
         unimplemented!()
     }
 
@@ -476,14 +476,14 @@ impl Window {
                     let (current_width, current_height) = self.current_size.get();
                     if current_width != cfg_event.width || current_height != cfg_event.height {
                         self.current_size.set((cfg_event.width, cfg_event.height));
-                        events.push_back(Resized(cfg_event.width as uint, cfg_event.height as uint));
+                        events.push_back(Resized(cfg_event.width as usize, cfg_event.height as usize));
                     }
                 },
 
                 ffi::MotionNotify => {
                     use events::Event::MouseMoved;
                     let event: &ffi::XMotionEvent = unsafe { mem::transmute(&xev) };
-                    events.push_back(MouseMoved((event.x as int, event.y as int)));
+                    events.push_back(MouseMoved((event.x as isize, event.y as isize)));
                 },
 
                 ffi::KeyPress | ffi::KeyRelease => {
@@ -507,7 +507,7 @@ impl Window {
                             mem::transmute(buffer.as_mut_ptr()),
                             buffer.len() as libc::c_int, ptr::null_mut(), ptr::null_mut());
 
-                        str::from_utf8(buffer.as_slice().slice_to(count as uint))
+                        str::from_utf8(buffer.as_slice().slice_to(count as usize))
                             .unwrap_or("").to_string()
                     };
 
@@ -609,6 +609,6 @@ impl Window {
         ::Api::OpenGl
     }
 
-    pub fn set_window_resize_callback(&mut self, _: Option<fn(uint, uint)>) {
+    pub fn set_window_resize_callback(&mut self, _: Option<fn(usize, usize)>) {
     }
 }

--- a/src/x11/window/monitor.rs
+++ b/src/x11/window/monitor.rs
@@ -3,7 +3,7 @@ use std::collections::RingBuf;
 use super::super::ffi;
 use super::ensure_thread_init;
 
-pub struct MonitorID(pub uint);
+pub struct MonitorID(pub usize);
 
 pub fn get_available_monitors() -> RingBuf<MonitorID> {
     ensure_thread_init();
@@ -18,7 +18,7 @@ pub fn get_available_monitors() -> RingBuf<MonitorID> {
     };
 
     let mut monitors = RingBuf::new();
-    monitors.extend(range(0, nb_monitors).map(|i| MonitorID(i as uint)));
+    monitors.extend(range(0, nb_monitors).map(|i| MonitorID(i as usize)));
     monitors
 }
 
@@ -34,7 +34,7 @@ pub fn get_primary_monitor() -> MonitorID {
         primary_monitor
     };
 
-    MonitorID(primary_monitor as uint)
+    MonitorID(primary_monitor as usize)
 }
 
 impl MonitorID {
@@ -43,7 +43,7 @@ impl MonitorID {
         Some(format!("Monitor #{}", screen_num))
     }
 
-    pub fn get_dimensions(&self) -> (uint, uint) {
+    pub fn get_dimensions(&self) -> (usize, usize) {
         let dimensions = unsafe {
             let display = ffi::XOpenDisplay(ptr::null());
             let MonitorID(screen_num) = *self;
@@ -51,7 +51,7 @@ impl MonitorID {
             let width = ffi::XWidthOfScreen(screen);
             let height = ffi::XHeightOfScreen(screen);
             ffi::XCloseDisplay(display);
-            (width as uint, height as uint)
+            (width as usize, height as usize)
         };
 
         dimensions


### PR DESCRIPTION
From https://github.com/rust-lang/rfcs/pull/544 the types uint/int were
renamed to usize/isize.