### PR TITLE
Remove unnecessary inner method in OSX window constructor

### DIFF
--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -32,9 +32,9 @@ fn main() {
         run(window3, (1.0, 0.0, 0.0, 1.0));
     });
 
-    t1.join();
-    t2.join();
-    t3.join();
+    let _ = t1.join();
+    let _ = t2.join();
+    let _ = t3.join();
 }
 
 #[cfg(feature = "window")]

--- a/src/osx/mod.rs
+++ b/src/osx/mod.rs
@@ -208,27 +208,25 @@ impl Window {
 
     fn create_window(dimensions: (u32, u32), title: &str, monitor: Option<MonitorID>) -> Option<id> {
         unsafe {
-            let scr_frame = match monitor {
-                Some(_) => {
-                    let screen = NSScreen::mainScreen(nil);
-                    NSScreen::frame(screen)
-                }
-                None    => {
-                    let (width, height) = dimensions;
-                    NSRect::new(NSPoint::new(0., 0.), NSSize::new(width as f64, height as f64))
-                }
+            let frame = if monitor.is_some() {
+                let screen = NSScreen::mainScreen(nil);
+                NSScreen::frame(screen)
+            } else {
+                let (width, height) = dimensions;
+                NSRect::new(NSPoint::new(0., 0.), NSSize::new(width as f64, height as f64))
             };
 
-             let masks = match monitor {
-                Some(_) => NSBorderlessWindowMask as NSUInteger,
-                None    => NSTitledWindowMask as NSUInteger |
-                           NSClosableWindowMask as NSUInteger |
-                           NSMiniaturizableWindowMask as NSUInteger |
-                           NSResizableWindowMask as NSUInteger,
+            let masks = if monitor.is_some() {
+                NSBorderlessWindowMask as NSUInteger
+            } else {
+                NSTitledWindowMask as NSUInteger |
+                NSClosableWindowMask as NSUInteger |
+                NSMiniaturizableWindowMask as NSUInteger |
+                NSResizableWindowMask as NSUInteger
             };
 
             let window = NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(
-                scr_frame,
+                frame,
                 masks,
                 NSBackingStoreBuffered,
                 false,


### PR DESCRIPTION
This made things a little hard to understand