### PR TITLE
`c_char` isn't always `i8`

### DIFF
--- a/src/x11/headless.rs
+++ b/src/x11/headless.rs
@@ -5,7 +5,7 @@ use libc;
 use std::{mem, ptr};
 use super::ffi;
 
-fn with_c_str<F, T>(s: &str, f: F) -> T where F: FnOnce(*const i8) -> T {
+fn with_c_str<F, T>(s: &str, f: F) -> T where F: FnOnce(*const libc::c_char) -> T {
     use std::ffi::CString;
     let c_str = CString::from_slice(s.as_bytes());
     f(c_str.as_slice_with_nul().as_ptr())    

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -24,7 +24,7 @@ fn ensure_thread_init() {
     });
 }
 
-fn with_c_str<F, T>(s: &str, f: F) -> T where F: FnOnce(*const i8) -> T {
+fn with_c_str<F, T>(s: &str, f: F) -> T where F: FnOnce(*const libc::c_char) -> T {
     use std::ffi::CString;
     let c_str = CString::from_slice(s.as_bytes());
     f(c_str.as_slice_with_nul().as_ptr())    


### PR DESCRIPTION
upstreaming https://github.com/servo/glutin/pull/12