### PR TITLE
Some GPU/driver combinations have glxCreateContextAttribsARB present, bu...

### DIFF
--- a/src/x11/ffi.rs
+++ b/src/x11/ffi.rs
@@ -1358,6 +1358,17 @@ pub struct XF86VidModeModeInfo {
     private: libc::c_long,
 }
 
+#[repr(C)]
+pub struct XErrorEvent {
+    pub type_: libc::c_int,
+    pub display: *mut Display,
+    pub serial: libc::c_ulong,
+    pub error_code: libc::c_char,
+    pub request_code: libc::c_char,
+    pub minor_code: libc::c_char,
+    pub resourceid: XID,
+}
+
 #[cfg(feature = "headless")]
 #[link(name = "OSMesa")]
 extern "C" {
@@ -1430,6 +1441,7 @@ extern "C" {
     pub fn XScreenOfDisplay(display: *mut Display, screen_number: libc::c_int) -> *const Screen;
     pub fn XWidthOfScreen(screen: *const Screen) -> libc::c_int;
     pub fn XHeightOfScreen(screen: *const Screen) -> libc::c_int;
+    pub fn XSetErrorHandler(callback: fn(display: *mut Display, event: *mut XErrorEvent) -> libc::c_int) -> libc::c_int;
 
     pub fn XCloseIM(im: XIM) -> Status;
     pub fn XOpenIM(display: *mut Display, db: XrmDatabase, res_name: *mut libc::c_char,

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -18,7 +18,7 @@ static THREAD_INIT: Once = ONCE_INIT;
 
 fn x_error_callback(_: *mut ffi::Display, event: *mut ffi::XErrorEvent) -> libc::c_int {
     unsafe {
-        println!("x error code={} major={} minor={}!", (*event).error_code, (*event).request_code, (*event).minor_code);
+        println!("[glutin] x error code={} major={} minor={}!", (*event).error_code, (*event).request_code, (*event).minor_code);
     }
     0
 }

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -16,10 +16,18 @@ mod monitor;
 
 static THREAD_INIT: Once = ONCE_INIT;
 
+fn x_error_callback(_: *mut ffi::Display, event: *mut ffi::XErrorEvent) -> libc::c_int {
+    unsafe {
+        println!("x error code={} major={} minor={}!", (*event).error_code, (*event).request_code, (*event).minor_code);
+    }
+    0
+}
+
 fn ensure_thread_init() {
     THREAD_INIT.call_once(|| {
         unsafe {
             ffi::XInitThreads();
+            ffi::XSetErrorHandler(x_error_callback);
         }
     });
 }
@@ -322,12 +330,16 @@ impl Window {
                 ptr::null()
             };
 
-            let context = if extra_functions.CreateContextAttribsARB.is_loaded() {
+            let mut context = if extra_functions.CreateContextAttribsARB.is_loaded() {
                 extra_functions.CreateContextAttribsARB(display as *mut ffi::glx_extra::types::Display,
                     fb_config, share, 1, attributes.as_ptr())
             } else {
-                ffi::glx::CreateContext(display, &mut visual_infos, share, 1)
+                ptr::null()
             };
+
+            if context.is_null() {
+                context = ffi::glx::CreateContext(display, &mut visual_infos, share, 1)
+            }
 
             if context.is_null() {
                 return Err(OsError(format!("GL context creation failed")));


### PR DESCRIPTION
...t it fails with an X error. In this case, catch the X error and fall back to the old method of creating a context.