### PR TITLE
Disable compiler unstable warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+#![allow(unstable)]
 extern crate gl_generator;
 extern crate khronos_api;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(unsafe_destructor)]
 #![unstable]
+#![allow(unstable)]
 
 //! The purpose of this library is to provide an OpenGL context on as many
 //!  platforms as possible.


### PR DESCRIPTION
To cleanup the compiler output when building, disable
warnings about using unstable crates/features