### PR TITLE
Remove deadcode warning in BuilderAttribs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ pub struct WindowBuilder<'a> {
 
 /// Attributes
 struct BuilderAttribs<'a> {
+    #[allow(dead_code)]
     headless: bool,
     strict: bool,
     sharing: Option<&'a winimpl::Window>,


### PR DESCRIPTION
In src/lib.rs remove the deadcode warning about the 'headless' builder
attribute. Headless is *actually* set to false or true depending on if
HeadlessRendererBuilder is used.