### PR TITLE
Rename enum variants of MouseButton

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -7,7 +7,7 @@ use {CreationError, Event, MouseCursor};
 use CreationError::OsError;
 use events::ElementState::{Pressed, Released};
 use events::Event::{MouseInput, MouseMoved};
-use events::MouseButton::LeftMouseButton;
+use events::MouseButton;
 
 use std::collections::RingBuf;
 
@@ -232,10 +232,10 @@ impl Window {
             match self.event_rx.try_recv() {
                 Ok(event) => match event {
                     android_glue::Event::EventDown => {
-                        events.push_back(MouseInput(Pressed, LeftMouseButton));
+                        events.push_back(MouseInput(Pressed, MouseButton::Left));
                     },
                     android_glue::Event::EventUp => {
-                        events.push_back(MouseInput(Released, LeftMouseButton));
+                        events.push_back(MouseInput(Released, MouseButton::Left));
                     },
                     android_glue::Event::EventMove(x, y) => {
                         events.push_back(MouseMoved((x as i32, y as i32)));

--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -29,7 +29,7 @@ use std::ascii::AsciiExt;
 
 use events::Event::{MouseInput, MouseMoved, ReceivedCharacter, KeyboardInput, MouseWheel};
 use events::ElementState::{Pressed, Released};
-use events::MouseButton::{LeftMouseButton, RightMouseButton};
+use events::MouseButton;
 use events;
 
 pub use self::monitor::{MonitorID, get_available_monitors, get_primary_monitor};
@@ -433,10 +433,10 @@ impl Window {
                 }
 
                 match msg_send()(event, selector("type")) {
-                    NSLeftMouseDown         => { events.push_back(MouseInput(Pressed, LeftMouseButton)); },
-                    NSLeftMouseUp           => { events.push_back(MouseInput(Released, LeftMouseButton)); },
-                    NSRightMouseDown        => { events.push_back(MouseInput(Pressed, RightMouseButton)); },
-                    NSRightMouseUp          => { events.push_back(MouseInput(Released, RightMouseButton)); },
+                    NSLeftMouseDown         => { events.push_back(MouseInput(Pressed, MouseButton::Left)); },
+                    NSLeftMouseUp           => { events.push_back(MouseInput(Released, MouseButton::Left)); },
+                    NSRightMouseDown        => { events.push_back(MouseInput(Pressed, MouseButton::Right)); },
+                    NSRightMouseUp          => { events.push_back(MouseInput(Released, MouseButton::Right)); },
                     NSMouseMoved            => {
                         let window_point: NSPoint = msg_send()(event, selector("locationInWindow"));
                         // let window_point = event.locationInWindow();

--- a/src/events.rs
+++ b/src/events.rs
@@ -46,10 +46,10 @@ pub enum ElementState {
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum MouseButton {
-    LeftMouseButton,
-    RightMouseButton,
-    MiddleMouseButton,
-    OtherMouseButton(u8),
+    Left,
+    Right,
+    Middle,
+    Other(u8),
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]

--- a/src/win32/init.rs
+++ b/src/win32/init.rs
@@ -542,49 +542,49 @@ extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
 
         winapi::WM_LBUTTONDOWN => {
             use events::Event::MouseInput;
-            use events::MouseButton::LeftMouseButton;
+            use events::MouseButton::Left;
             use events::ElementState::Pressed;
-            send_event(window, MouseInput(Pressed, LeftMouseButton));
+            send_event(window, MouseInput(Pressed, Left));
             0
         },
 
         winapi::WM_LBUTTONUP => {
             use events::Event::MouseInput;
-            use events::MouseButton::LeftMouseButton;
+            use events::MouseButton::Left;
             use events::ElementState::Released;
-            send_event(window, MouseInput(Released, LeftMouseButton));
+            send_event(window, MouseInput(Released, Left));
             0
         },
 
         winapi::WM_RBUTTONDOWN => {
             use events::Event::MouseInput;
-            use events::MouseButton::RightMouseButton;
+            use events::MouseButton::Right;
             use events::ElementState::Pressed;
-            send_event(window, MouseInput(Pressed, RightMouseButton));
+            send_event(window, MouseInput(Pressed, Right));
             0
         },
 
         winapi::WM_RBUTTONUP => {
             use events::Event::MouseInput;
-            use events::MouseButton::RightMouseButton;
+            use events::MouseButton::Right;
             use events::ElementState::Released;
-            send_event(window, MouseInput(Released, RightMouseButton));
+            send_event(window, MouseInput(Released, Right));
             0
         },
 
         winapi::WM_MBUTTONDOWN => {
             use events::Event::MouseInput;
-            use events::MouseButton::MiddleMouseButton;
+            use events::MouseButton::Middle;
             use events::ElementState::Pressed;
-            send_event(window, MouseInput(Pressed, MiddleMouseButton));
+            send_event(window, MouseInput(Pressed, Middle));
             0
         },
 
         winapi::WM_MBUTTONUP => {
             use events::Event::MouseInput;
-            use events::MouseButton::MiddleMouseButton;
+            use events::MouseButton::Middle;
             use events::ElementState::Released;
-            send_event(window, MouseInput(Released, MiddleMouseButton));
+            send_event(window, MouseInput(Released, Middle));
             0
         },
 

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -594,16 +594,16 @@ impl Window {
                 ffi::ButtonPress | ffi::ButtonRelease => {
                     use events::Event::{MouseInput, MouseWheel};
                     use events::ElementState::{Pressed, Released};
-                    use events::MouseButton::{LeftMouseButton, RightMouseButton, MiddleMouseButton};
+                    use events::MouseButton::{Left, Right, Middle};
 
                     let event: &ffi::XButtonEvent = unsafe { mem::transmute(&xev) };
 
                     let state = if xev.type_ == ffi::ButtonPress { Pressed } else { Released };
 
                     let button = match event.button {
-                        ffi::Button1 => Some(LeftMouseButton),
-                        ffi::Button2 => Some(MiddleMouseButton),
-                        ffi::Button3 => Some(RightMouseButton),
+                        ffi::Button1 => Some(Left),
+                        ffi::Button2 => Some(Middle),
+                        ffi::Button3 => Some(Right),
                         ffi::Button4 => {
                             events.push_back(MouseWheel(1));
                             None


### PR DESCRIPTION
With enums that are namespaced by default, it seems reasonable to be less redundant in the variant naming here.