### PR TITLE
Implement win32 initialization in a cleaner way

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,33 @@ impl BuilderAttribs<'static> {
     }
 }
 
+impl<'a> BuilderAttribs<'a> {
+    fn extract_non_static(mut self) -> (BuilderAttribs<'static>, Option<&'a winimpl::Window>) {
+        let sharing = self.sharing.take();
+
+        let new_attribs = BuilderAttribs {
+            headless: self.headless,
+            strict: self.strict,
+            sharing: None,
+            dimensions: self.dimensions,
+            title: self.title,
+            monitor: self.monitor,
+            gl_version: self.gl_version,
+            gl_debug: self.gl_debug,
+            vsync: self.vsync,
+            visible: self.visible,
+            multisampling: self.multisampling,
+            depth_bits: self.depth_bits,
+            stencil_bits: self.stencil_bits,
+            color_bits: self.color_bits,
+            alpha_bits: self.alpha_bits,
+            stereoscopy: self.stereoscopy,
+        };
+
+        (new_attribs, sharing)
+    }
+}
+
 #[cfg(feature = "window")]
 impl<'a> WindowBuilder<'a> {
     /// Initializes a new `WindowBuilder` with default values.

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -26,10 +26,8 @@ pub struct HeadlessContext(Window);
 impl HeadlessContext {
     /// See the docs in the crate root file.
     pub fn new(builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
-        let BuilderAttribs { dimensions, gl_version, gl_debug, .. } = builder;
-        init::new_window(dimensions, "".to_string(), None, gl_version, gl_debug, false, true,
-                         None, None)
-                         .map(|w| HeadlessContext(w))
+        let (builder, _) = builder.extract_non_static();
+        init::new_window(builder, None).map(|w| HeadlessContext(w))
     }
 
     /// See the docs in the crate root file.
@@ -86,11 +84,9 @@ unsafe impl Sync for Window {}
 impl Window {
     /// See the docs in the crate root file.
     pub fn new(builder: BuilderAttribs) -> Result<Window, CreationError> {
-        let BuilderAttribs { dimensions, title, monitor, gl_version,
-                             gl_debug, vsync, visible, sharing, multisampling, .. } = builder;
-        init::new_window(dimensions, title, monitor, gl_version, gl_debug, vsync,
-                         !visible, sharing.map(|w| init::ContextHack(w.context)),
-                         multisampling)
+        let (builder, sharing) = builder.extract_non_static();
+        let sharing = sharing.map(|w| init::ContextHack(w.context));
+        init::new_window(builder, sharing)
     }
 }
 


### PR DESCRIPTION
We pass the builder to the `new` function instead of extracting and passing values individually.

Extracted from #198