### PR TITLE
Improve the OpenGL context request system

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -11,7 +11,9 @@ use events::MouseButton;
 
 use std::collections::RingBuf;
 
+use Api;
 use BuilderAttribs;
+use GlRequest;
 
 pub struct Window {
     display: ffi::egl::types::EGLDisplay,
@@ -157,7 +159,10 @@ impl Window {
         android_glue::write_log("eglInitialize succeeded");
 
         let use_gles2 = match builder.gl_version {
-            Some((2, 0)) => true,
+            GlRequest::Specific(Api::OpenGlEs, (2, _)) => true,
+            GlRequest::Specific(Api::OpenGlEs, _) => false,
+            GlRequest::Specific(_, _) => panic!("Only OpenGL ES is supported"),     // FIXME: return a result
+            GlRequest::GlThenGles { opengles_version: (2, _), .. } => true,
             _ => false,
         };
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,6 +1,7 @@
 use Api;
 use BuilderAttribs;
 use CreationError;
+use GlRequest;
 
 use gl_common;
 use libc;
@@ -24,12 +25,16 @@ impl HeadlessRendererBuilder {
         }
     }
 
-    /// Requests to use a specific OpenGL version.
-    ///
-    /// Version is a (major, minor) pair. For example to request OpenGL 3.3
-    ///  you would pass `(3, 3)`.
+    /// THIS FUNCTION IS DEPRECATED
+    #[deprecated = "Use with_gl instead"]
     pub fn with_gl_version(mut self, version: (u32, u32)) -> HeadlessRendererBuilder {
-        self.attribs.gl_version = Some(version);
+        self.attribs.gl_version = GlRequest::Specific(::Api::OpenGl, (version.0 as u8, version.1 as u8));
+        self
+    }
+
+    /// Sets how the backend should choose the OpenGL API and version.
+    pub fn with_gl(mut self, request: GlRequest) -> HeadlessRendererBuilder {
+        self.attribs.gl_version = request;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,30 @@ pub enum Api {
     WebGl,
 }
 
+/// Describes the OpenGL API and version that are being requested when a context is created.
+#[derive(Debug, Copy, Clone)]
+pub enum GlRequest {
+    /// Request the latest version of the "best" API of this platform.
+    ///
+    /// On desktop, will try OpenGL.
+    Latest,
+
+    /// Request a specific version of a specific API.
+    ///
+    /// Example: `GlRequest::Specific(Api::OpenGl, (3, 3))`.
+    Specific(Api, (u8, u8)),
+
+    /// If OpenGL is available, create an OpenGL context with the specified `opengl_version`.
+    /// Else if OpenGL ES or WebGL is available, create a context with the
+    /// specified `opengles_version`.
+    GlThenGles {
+        /// The version to use for OpenGL.
+        opengl_version: (u8, u8),
+        /// The version to use for OpenGL ES.
+        opengles_version: (u8, u8),
+    },
+}
+
 #[derive(Debug, Copy)]
 pub enum MouseCursor {
     /// The platform-dependent default cursor.
@@ -194,7 +218,7 @@ struct BuilderAttribs<'a> {
     dimensions: Option<(u32, u32)>,
     title: String,
     monitor: Option<winimpl::MonitorID>,
-    gl_version: Option<(u32, u32)>,
+    gl_version: GlRequest,
     gl_debug: bool,
     vsync: bool,
     visible: bool,
@@ -215,7 +239,7 @@ impl BuilderAttribs<'static> {
             dimensions: None,
             title: "glutin window".to_string(),
             monitor: None,
-            gl_version: None,
+            gl_version: GlRequest::Latest,
             gl_debug: cfg!(ndebug),
             vsync: false,
             visible: true,

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,6 +5,7 @@ use Api;
 use BuilderAttribs;
 use CreationError;
 use Event;
+use GlRequest;
 use MouseCursor;
 
 use gl_common;
@@ -56,12 +57,16 @@ impl<'a> WindowBuilder<'a> {
         self
     }
 
-    /// Requests to use a specific OpenGL version.
-    ///
-    /// Version is a (major, minor) pair. For example to request OpenGL 3.3
-    ///  you would pass `(3, 3)`.
+    /// THIS FUNCTION IS DEPRECATED
+    #[deprecated = "Use with_gl instead"]
     pub fn with_gl_version(mut self, version: (u32, u32)) -> WindowBuilder<'a> {
-        self.attribs.gl_version = Some(version);
+        self.attribs.gl_version = GlRequest::Specific(::Api::OpenGl, (version.0 as u8, version.1 as u8));
+        self
+    }
+
+    /// Sets how the backend should choose the OpenGL API and version.
+    pub fn with_gl(mut self, request: GlRequest) -> WindowBuilder<'a> {
+        self.attribs.gl_version = request;
         self
     }
 


### PR DESCRIPTION
Before: `builder.with_gl_version((3, 2))`
After: `builder.with_gl(glutin::GlRequest::Specific(glutin::Api::OpenGl, (3, 2)))`

The reason for this new API is to be more flexible in regards to OpenGL ES and WebGL. It is possible to request either the latest version of any API, or a specific version of a specific API, or a specific version of either GL or GLES.

The `with_gl_version` function is deprecated but not removed.