### PR TITLE
expose platform-specific window handle (currently Win only)

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -329,6 +329,10 @@ impl Window {
         self.display as *mut libc::c_void
     }
 
+    pub fn platform_window(&self) -> *mut libc::c_void {
+        unimplemented!()
+    }
+
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGlEs
     }

--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -604,6 +604,10 @@ impl Window {
         unimplemented!()
     }
 
+    pub fn platform_window(&self) -> *mut libc::c_void {
+        unimplemented!()
+    }
+
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGl
     }

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -212,6 +212,10 @@ impl Window {
         unimplemented!()
     }
 
+    pub fn platform_window(&self) -> *mut libc::c_void {
+        self.window as *mut libc::c_void
+    }
+
     /// See the docs in the crate root file.
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGl

--- a/src/window.rs
+++ b/src/window.rs
@@ -357,6 +357,14 @@ impl Window {
         self.window.platform_display()
     }
 
+    /// Gets the native platform specific window handle. This is
+    /// typically only required when integrating with other libraries
+    /// that need this information.
+    #[inline]
+    pub unsafe fn platform_window(&self) -> *mut libc::c_void {
+        self.window.platform_window()
+    }
+
     /// Returns the API that is currently provided by this window.
     ///
     /// - On Windows and OS/X, this always returns `OpenGl`.

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -719,6 +719,10 @@ impl Window {
         self.x.display as *mut libc::c_void
     }
 
+    pub fn platform_window(&self) -> *mut libc::c_void {
+        unimplemented!()
+    }
+
     /// See the docs in the crate root file.
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGl


### PR DESCRIPTION
Similar scenario to platform_display, I suspect. In this case, we're working with the Oculus SDK, which requires passing them the HWND of the render window on Windows.

I didn't implement for other platforms because I have no easy way to test. Let me know if I should rough in implementations anyway, or just open issues for the unimplemented stubs for other platforms.