### PR TITLE
Make headless rendering work on Mac OS X 10.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "glutin"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["tomaka <pierre.krieger1708@gmail.com>"]
 description = "Cross-plaform OpenGL context provider. Important: the crates.io only supports Windows and Linux for the moment."
 keywords = ["windowing", "opengl"]

--- a/src/cocoa/headless.rs
+++ b/src/cocoa/headless.rs
@@ -28,13 +28,9 @@ impl HeadlessContext {
         let (width, height) = builder.dimensions.unwrap_or((1024, 768));
         let context = unsafe {
             let attributes = [
+                NSOpenGLPFAAccelerated as u32,
+                NSOpenGLPFAAllowOfflineRenderers as u32,
                 NSOpenGLPFADoubleBuffer as u32,
-                NSOpenGLPFAClosestPolicy as u32,
-                NSOpenGLPFAColorSize as u32, 24,
-                NSOpenGLPFAAlphaSize as u32, 8,
-                NSOpenGLPFADepthSize as u32, 24,
-                NSOpenGLPFAStencilSize as u32, 8,
-                NSOpenGLPFAOffScreen as u32,
                 0
             ];
 


### PR DESCRIPTION
The pixel format attributes match what gecko uses for offscreen rendering.