### PR TITLE
Cocoa fixes: memory leaks, monitor handling, is_current()

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -14,6 +14,7 @@ use std::collections::VecDeque;
 use Api;
 use BuilderAttribs;
 use GlRequest;
+use NativeMonitorID;
 
 pub struct Window {
     display: ffi::egl::types::EGLDisplay,
@@ -39,6 +40,10 @@ pub fn get_primary_monitor() -> MonitorID {
 impl MonitorID {
     pub fn get_name(&self) -> Option<String> {
         Some("Primary".to_string())
+    }
+
+    pub fn get_native_identifier(&self) -> NativeMonitorID {
+        NativeMonitorID::Unavailable
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use Api;
 use BuilderAttribs;
 use GlRequest;
-use NativeMonitorID;
+use native_monitor::NativeMonitorId;
 
 pub struct Window {
     display: ffi::egl::types::EGLDisplay,
@@ -42,8 +42,8 @@ impl MonitorID {
         Some("Primary".to_string())
     }
 
-    pub fn get_native_identifier(&self) -> NativeMonitorID {
-        NativeMonitorID::Unavailable
+    pub fn get_native_identifier(&self) -> NativeMonitorId {
+        NativeMonitorId::Unavailable
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -617,7 +617,15 @@ impl Window {
     }
 
     pub fn is_current(&self) -> bool {
-        unimplemented!()
+        unsafe {
+            let current = NSOpenGLContext::currentContext(nil);
+            if current != nil {
+                let is_equal: bool = msg_send()(current, selector("isEqual:"), *self.context);
+                is_equal
+            } else {
+                false
+            }
+        }
     }
 
     pub fn get_proc_address(&self, _addr: &str) -> *const () {

--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -8,7 +8,7 @@ use libc;
 use Api;
 use BuilderAttribs;
 use GlRequest;
-use NativeMonitorID;
+use native_monitor::NativeMonitorId;
 
 use cocoa::base::{Class, id, YES, NO, NSUInteger, nil, objc_allocateClassPair, class, objc_registerClassPair};
 use cocoa::base::{selector, msg_send, msg_send_stret, class_addMethod, class_addIvar};
@@ -409,7 +409,7 @@ impl Window {
         unsafe {
             let screen = monitor.map(|monitor_id| {
                 let native_id = match monitor_id.get_native_identifier() {
-                    NativeMonitorID::Numeric(num) => num,
+                    NativeMonitorId::Numeric(num) => num,
                     _ => panic!("OS X monitors should always have a numeric native ID")
                 };
                 let matching_screen = {

--- a/src/cocoa/monitor.rs
+++ b/src/cocoa/monitor.rs
@@ -1,5 +1,6 @@
 use core_graphics::display;
 use std::collections::VecDeque;
+use window::NativeMonitorID;
 
 pub struct MonitorID(u32);
 
@@ -33,6 +34,11 @@ impl MonitorID {
             display::CGDisplayModelNumber(display_id)
         };
         Some(format!("Monitor #{}", screen_num))
+    }
+
+    pub fn get_native_identifier(&self) -> NativeMonitorID {
+        let MonitorID(display_id) = *self;
+        NativeMonitorID::Numeric(display_id)
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/cocoa/monitor.rs
+++ b/src/cocoa/monitor.rs
@@ -1,6 +1,6 @@
 use core_graphics::display;
 use std::collections::VecDeque;
-use window::NativeMonitorID;
+use native_monitor::NativeMonitorId;
 
 pub struct MonitorID(u32);
 
@@ -36,9 +36,9 @@ impl MonitorID {
         Some(format!("Monitor #{}", screen_num))
     }
 
-    pub fn get_native_identifier(&self) -> NativeMonitorID {
+    pub fn get_native_identifier(&self) -> NativeMonitorId {
         let MonitorID(display_id) = *self;
-        NativeMonitorID::Numeric(display_id)
+        NativeMonitorId::Numeric(display_id)
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,9 @@ pub use headless::{HeadlessRendererBuilder, HeadlessContext};
 #[cfg(feature = "window")]
 pub use window::{WindowBuilder, Window, WindowProxy, PollEventsIterator, WaitEventsIterator};
 #[cfg(feature = "window")]
-pub use window::{AvailableMonitorsIter, NativeMonitorID, MonitorID, get_available_monitors, get_primary_monitor};
+pub use window::{AvailableMonitorsIter, MonitorID, get_available_monitors, get_primary_monitor};
+#[cfg(feature = "window")]
+pub use native_monitor::NativeMonitorId;
 
 #[cfg(all(not(target_os = "windows"), not(target_os = "linux"), not(target_os = "macos"), not(target_os = "android")))]
 use this_platform_is_not_supported;
@@ -322,3 +324,20 @@ impl<'a> BuilderAttribs<'a> {
                       .expect("Could not find compliant pixel format")
     }
 }
+
+mod native_monitor {
+    /// Native platform identifier for a monitor. Different platforms use fundamentally different types
+    /// to represent a monitor ID.
+    #[derive(PartialEq, Eq)]
+    pub enum NativeMonitorId {
+        /// Cocoa and X11 use a numeric identifier to represent a monitor.
+        Numeric(u32),
+
+        /// Win32 uses a Unicode string to represent a monitor.
+        Name(String),
+
+        /// Other platforms (Android) don't support monitor identification.
+        Unavailable
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use headless::{HeadlessRendererBuilder, HeadlessContext};
 #[cfg(feature = "window")]
 pub use window::{WindowBuilder, Window, WindowProxy, PollEventsIterator, WaitEventsIterator};
 #[cfg(feature = "window")]
-pub use window::{AvailableMonitorsIter, MonitorID, get_available_monitors, get_primary_monitor};
+pub use window::{AvailableMonitorsIter, NativeMonitorID, MonitorID, get_available_monitors, get_primary_monitor};
 
 #[cfg(all(not(target_os = "windows"), not(target_os = "linux"), not(target_os = "macos"), not(target_os = "android")))]
 use this_platform_is_not_supported;

--- a/src/win32/monitor.rs
+++ b/src/win32/monitor.rs
@@ -3,6 +3,8 @@ use user32;
 
 use std::collections::VecDeque;
 
+use NativeMonitorID;
+
 /// Win32 implementation of the main `MonitorID` object.
 pub struct MonitorID {
     /// The system name of the monitor.
@@ -111,6 +113,11 @@ impl MonitorID {
     /// See the docs if the crate root file.
     pub fn get_name(&self) -> Option<String> {
         Some(self.readable_name.clone())
+    }
+
+    /// See the docs of the crate root file.
+    pub fn get_native_identifier(&self) -> NativeMonitorID {
+        NativeMonitorID::Name(self.readable_name.clone())
     }
 
     /// See the docs if the crate root file.

--- a/src/win32/monitor.rs
+++ b/src/win32/monitor.rs
@@ -3,7 +3,7 @@ use user32;
 
 use std::collections::VecDeque;
 
-use NativeMonitorID;
+use native_monitor::NativeMonitorId;
 
 /// Win32 implementation of the main `MonitorID` object.
 pub struct MonitorID {
@@ -116,8 +116,8 @@ impl MonitorID {
     }
 
     /// See the docs of the crate root file.
-    pub fn get_native_identifier(&self) -> NativeMonitorID {
-        NativeMonitorID::Name(self.readable_name.clone())
+    pub fn get_native_identifier(&self) -> NativeMonitorId {
+        NativeMonitorId::Name(self.readable_name.clone())
     }
 
     /// See the docs if the crate root file.

--- a/src/window.rs
+++ b/src/window.rs
@@ -7,6 +7,7 @@ use CreationError;
 use Event;
 use GlRequest;
 use MouseCursor;
+use native_monitor::NativeMonitorId;
 
 use gl_common;
 use libc;
@@ -500,19 +501,6 @@ pub fn get_primary_monitor() -> MonitorID {
     MonitorID(winimpl::get_primary_monitor())
 }
 
-/// Native platform identifier for a monitor. Different platforms use fundamentally different types
-/// to represent a monitor ID.
-pub enum NativeMonitorID {
-    /// Cocoa and X11 use a numeric identifier to represent a monitor.
-    Numeric(u32),
-
-    /// Win32 uses a Unicode string to represent a monitor.
-    Name(String),
-
-    /// Other platforms (Android) don't support monitor identification.
-    Unavailable
-}
-
 /// Identifier for a monitor.
 pub struct MonitorID(winimpl::MonitorID);
 
@@ -524,7 +512,7 @@ impl MonitorID {
     }
 
     /// Returns the native platform identifier for this monitor.
-    pub fn get_native_identifier(&self) -> NativeMonitorID {
+    pub fn get_native_identifier(&self) -> NativeMonitorId {
         let &MonitorID(ref id) = self;
         id.get_native_identifier()
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -500,6 +500,19 @@ pub fn get_primary_monitor() -> MonitorID {
     MonitorID(winimpl::get_primary_monitor())
 }
 
+/// Native platform identifier for a monitor. Different platforms use fundamentally different types
+/// to represent a monitor ID.
+pub enum NativeMonitorID {
+    /// Cocoa and X11 use a numeric identifier to represent a monitor.
+    Numeric(u32),
+
+    /// Win32 uses a Unicode string to represent a monitor.
+    Name(String),
+
+    /// Other platforms (Android) don't support monitor identification.
+    Unavailable
+}
+
 /// Identifier for a monitor.
 pub struct MonitorID(winimpl::MonitorID);
 
@@ -508,6 +521,12 @@ impl MonitorID {
     pub fn get_name(&self) -> Option<String> {
         let &MonitorID(ref id) = self;
         id.get_name()
+    }
+
+    /// Returns the native platform identifier for this monitor.
+    pub fn get_native_identifier(&self) -> NativeMonitorID {
+        let &MonitorID(ref id) = self;
+        id.get_native_identifier()
     }
 
     /// Returns the number of pixels currently displayed on the monitor.

--- a/src/x11/window/monitor.rs
+++ b/src/x11/window/monitor.rs
@@ -2,7 +2,7 @@ use std::ptr;
 use std::collections::VecDeque;
 use super::super::ffi;
 use super::ensure_thread_init;
-use window::NativeMonitorID;
+use native_monitor::NativeMonitorId;
 
 pub struct MonitorID(pub u32);
 
@@ -44,9 +44,9 @@ impl MonitorID {
         Some(format!("Monitor #{}", screen_num))
     }
 
-    pub fn get_native_identifier(&self) -> NativeMonitorID {
+    pub fn get_native_identifier(&self) -> NativeMonitorId {
         let MonitorID(screen_num) = *self;
-        NativeMonitorID::Numeric(screen_num)
+        NativeMonitorId::Numeric(screen_num)
     }
 
     pub fn get_dimensions(&self) -> (u32, u32) {

--- a/src/x11/window/monitor.rs
+++ b/src/x11/window/monitor.rs
@@ -2,6 +2,7 @@ use std::ptr;
 use std::collections::VecDeque;
 use super::super::ffi;
 use super::ensure_thread_init;
+use window::NativeMonitorID;
 
 pub struct MonitorID(pub u32);
 

--- a/src/x11/window/monitor.rs
+++ b/src/x11/window/monitor.rs
@@ -43,6 +43,11 @@ impl MonitorID {
         Some(format!("Monitor #{}", screen_num))
     }
 
+    pub fn get_native_identifier(&self) -> NativeMonitorID {
+        let MonitorID(screen_num) = *self;
+        NativeMonitorID::Numeric(screen_num)
+    }
+
     pub fn get_dimensions(&self) -> (u32, u32) {
         let dimensions = unsafe {
             let display = ffi::XOpenDisplay(ptr::null());


### PR DESCRIPTION
cc @bjz  

Sorry for the slightly multi-purpose PR. They're inter-related (for me, at least), but I can break this apart further if necessary.

Covers the following fixes:

* Makes sure retain/release is happening as alloc'd or retained `NSObject`s are passed around the cocoa backend
* Exposes an enum that gives raw access to the platform-native monitor identifier. For both external library integration, and for the next item.
* Fix with_fullscreen() behavior on Cocoa to correctly select the passed-in monitor, rather than always using `NSScreen mainScreen`.
* Add missing implementation for Window::is_current() in cocoa