### PR TITLE
Use objc crate for Objective-C runtime functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clock_ticks = "*"
 version = "0"
 
 [target.x86_64-apple-darwin.dependencies]
+objc = "0.1"
 glutin_cocoa = "0"
 glutin_core_graphics = "0"
 glutin_core_foundation = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,23 +30,10 @@ clock_ticks = "*"
 [target.arm-linux-androideabi.dependencies.android_glue]
 version = "0"
 
-[target.i686-apple-darwin.dependencies.glutin_cocoa]
-version = "0"
-
-[target.x86_64-apple-darwin.dependencies.glutin_cocoa]
-version = "0"
-
-[target.i686-apple-darwin.dependencies.glutin_core_graphics]
-version = "0"
-
-[target.x86_64-apple-darwin.dependencies.glutin_core_graphics]
-version = "0"
-
-[target.i686-apple-darwin.dependencies.glutin_core_foundation]
-version = "0"
-
-[target.x86_64-apple-darwin.dependencies.glutin_core_foundation]
-version = "0"
+[target.x86_64-apple-darwin.dependencies]
+glutin_cocoa = "0"
+glutin_core_graphics = "0"
+glutin_core_foundation = "0"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ extern crate "gdi32-sys" as gdi32;
 #[cfg(target_os = "windows")]
 extern crate "user32-sys" as user32;
 #[cfg(target_os = "macos")]
+#[macro_use]
+extern crate objc;
+#[cfg(target_os = "macos")]
 extern crate cocoa;
 #[cfg(target_os = "macos")]
 extern crate core_foundation;


### PR DESCRIPTION
I've been working on an [objc crate](https://crates.io/crates/objc) for interoperating with the Objective-C runtime. glutin is one of the most prominent crates using Objective-C from Rust, so I'm very interested in getting your opinion of the objc crate and hearing if you feel like it would be useful to glutin.

This pull request demonstrates how using the objc crate in glutin would look. This change requires the cocoa crate to use objc, though, so it'd require servo/rust-cocoa#71 as a prerequisite.

I've tested this with the cocoa change and all the examples still work, but I'm not too familiar with glutin, so let me know if there is more thorough testing I can do.

Let me know if the objc crate looks like it could be useful or if you have any suggestions for me!