### PR TITLE
Win32 monitor handling

### DIFF
--- a/src/win32/init.rs
+++ b/src/win32/init.rs
@@ -164,6 +164,12 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
             (None, None)
         };
 
+        let (x, y) = if builder.monitor.is_some() {
+            (Some(rect.left), Some(rect.top))
+        } else {
+            (None, None)
+        };
+
         let style = if !builder.visible || builder.headless {
             style
         } else {
@@ -173,8 +179,7 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
         let handle = user32::CreateWindowExW(ex_style, class_name.as_ptr(),
             title.as_ptr() as winapi::LPCWSTR,
             style | winapi::WS_CLIPSIBLINGS | winapi::WS_CLIPCHILDREN,
-            if builder.monitor.is_some() { 0 } else { winapi::CW_USEDEFAULT },
-            if builder.monitor.is_some() { 0 } else { winapi::CW_USEDEFAULT },
+            x.unwrap_or(winapi::CW_USEDEFAULT), y.unwrap_or(winapi::CW_USEDEFAULT),
             width.unwrap_or(winapi::CW_USEDEFAULT), height.unwrap_or(winapi::CW_USEDEFAULT),
             ptr::null_mut(), ptr::null_mut(), kernel32::GetModuleHandleW(ptr::null()),
             ptr::null_mut());

--- a/src/win32/init.rs
+++ b/src/win32/init.rs
@@ -301,7 +301,7 @@ unsafe fn switch_to_fullscreen(rect: &mut winapi::RECT, monitor: &MonitorID)
     screen_settings.dmBitsPerPel = 32;      // TODO: ?
     screen_settings.dmFields = winapi::DM_BITSPERPEL | winapi::DM_PELSWIDTH | winapi::DM_PELSHEIGHT;
 
-    let result = user32::ChangeDisplaySettingsExW(monitor.get_system_name().as_ptr(),
+    let result = user32::ChangeDisplaySettingsExW(monitor.get_adapter_name().as_ptr(),
                                                   &mut screen_settings, ptr::null_mut(),
                                                   winapi::CDS_FULLSCREEN, ptr::null_mut());
     


### PR DESCRIPTION
Two issues with Win32 monitor handling:

* The rect top left is being ignored when creating a window, even with a monitor specified. This means the window is sized appropriately, but doesn't appear on the correct monitor. Fixed in 1c20ff8.
* `get_available_monitors()` is enumerating display adapters, but not monitors. This has two implications: the friendly names for monitors are less specific, and the native platform identifier for a monitor is incomplete. Fixed in 1c9c5c0.

This still fetches resolution/position at the adapter level. On all of my test hardware, there's a 1:1 mapping between monitors and adapters. I don't know when this isn't true. An alternative is to use `EnumDisplayMonitors` and `GetMonitorInfo` to extract dimensions and positions, but it's a larger/riskier change.