### PR TITLE
Cursor grabbing

### DIFF
--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -42,6 +42,11 @@ fn main() {
                               .ok().expect("could not grab mouse cursor");
                     }
                 },
+
+                a @ Event::MouseMoved(_) => {
+                    println!("{:?}", a);
+                },
+
                 _ => (),
             }
             

--- a/src/win32/init.rs
+++ b/src/win32/init.rs
@@ -15,11 +15,13 @@ use Api;
 use BuilderAttribs;
 use CreationError;
 use CreationError::OsError;
+use CursorState;
 use GlRequest;
 use PixelFormat;
 
 use std::ffi::CString;
 use std::sync::mpsc::channel;
+use std::sync::Mutex;
 
 use libc;
 use super::gl;
@@ -250,6 +252,7 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
         gl_library: gl_library,
         events_receiver: events_receiver,
         is_closed: AtomicBool::new(false),
+        cursor_state: Mutex::new(CursorState::Normal),
     })
 }
 
@@ -265,7 +268,7 @@ unsafe fn register_window_class() -> Vec<u16> {
         cbWndExtra: 0,
         hInstance: kernel32::GetModuleHandleW(ptr::null()),
         hIcon: ptr::null_mut(),
-        hCursor: ptr::null_mut(),
+        hCursor: ptr::null_mut(),       // must be null in order for cursor state to work properly
         hbrBackground: ptr::null_mut(),
         lpszMenuName: ptr::null(),
         lpszClassName: class_name.as_ptr(),

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -292,9 +292,11 @@ impl Window {
                 unsafe {
                     user32::SetCursor(ptr::null_mut());
                     let mut rect = mem::uninitialized();
-                    if user32::GetWindowRect(self.window.0, &mut rect) == 0 {
+                    if user32::GetClientRect(self.window.0, &mut rect) == 0 {
                         return Err(format!("GetWindowRect failed"));
                     }
+                    user32::ClientToScreen(self.window.0, mem::transmute(&mut rect.left));
+                    user32::ClientToScreen(self.window.0, mem::transmute(&mut rect.right));
                     if user32::ClipCursor(&rect) == 0 {
                         return Err(format!("ClipCursor failed"));
                     }


### PR DESCRIPTION
- Replaces `grab_cursor` and `ungrab_cursor` by `set_cursor_state`.
- Partially implement this on win32.
- A few minor fixes.
