### PR TITLE
Fix default OpenGL debug flag being the opposite of what it should be

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ impl BuilderAttribs<'static> {
             title: "glutin window".to_string(),
             monitor: None,
             gl_version: GlRequest::Latest,
-            gl_debug: cfg!(ndebug),
+            gl_debug: !cfg!(ndebug),
             vsync: false,
             visible: true,
             multisampling: None,

--- a/src/window.rs
+++ b/src/window.rs
@@ -74,7 +74,7 @@ impl<'a> WindowBuilder<'a> {
 
     /// Sets the *debug* flag for the OpenGL context.
     ///
-    /// The default value for this flag is `cfg!(ndebug)`, which means that it's enabled
+    /// The default value for this flag is `!cfg!(ndebug)`, which means that it's enabled
     /// when you run `cargo build` and disabled when you run `cargo build --release`.
     pub fn with_gl_debug_flag(mut self, flag: bool) -> WindowBuilder<'a> {
         self.attribs.gl_debug = flag;


### PR DESCRIPTION
Right now by default glutin create a debug OpenGL context if you use `cargo build --release`, and a non-debug OpenGL context if you use `cargo build`.

This is the opposite of what it should do.