### PR TITLE
Add support for GLES on Win32

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,9 +26,13 @@ fn main() {
                                         khronos_api::WGL_XML,
                                         vec![
                                             "WGL_ARB_create_context".to_string(),
-                                            "WGL_EXT_swap_control".to_string(),
-                                            "WGL_ARB_pixel_format".to_string(),
+                                            "WGL_ARB_create_context_profile".to_string(),
+                                            "WGL_ARB_extensions_string".to_string(),
                                             "WGL_ARB_framebuffer_sRGB".to_string(),
+                                            "WGL_ARB_pixel_format".to_string(),
+                                            "WGL_EXT_create_context_es2_profile".to_string(),
+                                            "WGL_EXT_extensions_string".to_string(),
+                                            "WGL_EXT_swap_control".to_string(),
                                         ],
                                         "1.0", "core", &mut file).unwrap();
     }


### PR DESCRIPTION
With `WGL_EXT_create_context_es2_profile`.

This extension is only supported on nVidia and maybe Intel drivers.