### PR TITLE
README del note that set_cursor isnt implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ fn main() {
  - Some events are not implemented
  - Implementation is still work-in-progress
  - Vsync not implemented
- - Changing the cursor (set_cursor) is not implemented
 
 ### Win32
 


### PR DESCRIPTION
Update README.md to reflect that commit https://github.com/tomaka/glutin/commit/903c9b1aad951e683de08c1d902a12c95bcd84c2 implemented set_cursor on OSX. 