### PR TITLE
Update OSX to compile on stable rust

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-#![feature(convert)]
-
 extern crate gl_generator;
 extern crate khronos_api;
 

--- a/examples-disabled/fullscreen.rs
+++ b/examples-disabled/fullscreen.rs
@@ -1,5 +1,3 @@
-#![feature(std_misc)]
-
 #[cfg(target_os = "android")]
 #[macro_use]
 extern crate android_glue;

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,5 +1,3 @@
-#![feature(std_misc)]
-
 #[cfg(target_os = "android")]
 #[macro_use]
 extern crate android_glue;

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -1,5 +1,3 @@
-#![feature(std_misc)]
-
 #[cfg(target_os = "android")]
 #[macro_use]
 extern crate android_glue;

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,5 +1,3 @@
-#![feature(std_misc)]
-
 #[cfg(target_os = "android")]
 #[macro_use]
 extern crate android_glue;

--- a/examples/vsync.rs
+++ b/examples/vsync.rs
@@ -1,5 +1,3 @@
-#![feature(std_misc)]
-
 #[cfg(target_os = "android")]
 #[macro_use]
 extern crate android_glue;

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,5 +1,3 @@
-#![feature(std_misc)]
-
 #[cfg(target_os = "android")]
 #[macro_use]
 extern crate android_glue;

--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -719,15 +719,5 @@ impl Clone for IdRef {
         }
         IdRef(self.0)
     }
-
-    fn clone_from(&mut self, source: &IdRef) {
-        if source.0 != nil {
-            let _: id = unsafe { msg_send![source.0, retain] };
-        }
-        if self.0 != nil {
-            let _: () = unsafe { msg_send![self.0, release] };
-        }
-        self.0 = source.0;
-    }
 }
 


### PR DESCRIPTION
glutin wasn't compiling on OSX because `clone_from`, an unstable method, was implemented for `IdRef`. Deleting the method fixes this.

Also removed unused feature toggles from build.rs and examples so they will compile on the beta channel.