### PR TITLE
Fix OS X window closing bug

### DIFF
--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -75,7 +75,7 @@ impl WindowDelegate {
                 let state = state as *mut DelegateState;
                 (*state).is_closed = true;
             }
-            NO
+            YES
         }
 
         extern fn window_did_resize(this: &Object, _: Sel, _: id) {


### PR DESCRIPTION
This is hilarious. I've been trying to find and fix this bug for ages.

This fixes the ```glutin::Event::Closed``` bug on OS X.