### PR TITLE
Adds get_pixel_format() to Window

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -15,6 +15,7 @@ use Api;
 use BuilderAttribs;
 use CursorState;
 use GlRequest;
+use PixelFormat;
 use native_monitor::NativeMonitorId;
 
 pub struct Window {
@@ -351,6 +352,10 @@ impl Window {
 
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGlEs
+    }
+
+    pub fn get_pixel_format(&self) -> PixelFormat {
+        unimplemented!();
     }
 
     pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {

--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -8,6 +8,7 @@ use libc;
 use Api;
 use BuilderAttribs;
 use GlRequest;
+use PixelFormat;
 use native_monitor::NativeMonitorId;
 
 use objc::runtime::{Class, Object, Sel, BOOL, YES, NO};
@@ -614,6 +615,10 @@ impl Window {
 
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGl
+    }
+
+    pub fn get_pixel_format(&self) -> PixelFormat {
+        unimplemented!();
     }
 
     pub fn set_window_resize_callback(&mut self, callback: Option<fn(u32, u32)>) {

--- a/src/win32/init.rs
+++ b/src/win32/init.rs
@@ -203,16 +203,17 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
     };
 
     // calling SetPixelFormat
-    {
+    let pixel_format = {
         let formats = if extra_functions.GetPixelFormatAttribivARB.is_loaded() {
             enumerate_arb_pixel_formats(&extra_functions, &real_window)
         } else {
             enumerate_native_pixel_formats(&real_window)
         };
 
-        let (id, _) = try!(builder.choose_pixel_format(formats.into_iter().map(|(a, b)| (b, a))));
+        let (id, f) = try!(builder.choose_pixel_format(formats.into_iter().map(|(a, b)| (b, a))));
         try!(set_pixel_format(&real_window, id));
-    }
+        f
+    };
 
     // creating the OpenGL context
     let context = try!(create_context(Some((&extra_functions, &builder)), &real_window,
@@ -263,6 +264,7 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
         events_receiver: events_receiver,
         is_closed: AtomicBool::new(false),
         cursor_state: cursor_state,
+        pixel_format: pixel_format,
     })
 }
 

--- a/src/win32/mod.rs
+++ b/src/win32/mod.rs
@@ -13,6 +13,7 @@ use libc;
 use {CreationError, Event, MouseCursor};
 use CursorState;
 
+use PixelFormat;
 use BuilderAttribs;
 
 pub use self::headless::HeadlessContext;
@@ -53,6 +54,9 @@ pub struct Window {
 
     /// The current cursor state.
     cursor_state: Arc<Mutex<CursorState>>,
+
+    /// The pixel format that has been used to create this window.
+    pixel_format: PixelFormat,
 }
 
 unsafe impl Send for Window {}
@@ -256,6 +260,10 @@ impl Window {
     /// See the docs in the crate root file.
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGl
+    }
+
+    pub fn get_pixel_format(&self) -> PixelFormat {
+        self.pixel_format.clone()
     }
 
     pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,6 +8,7 @@ use CursorState;
 use Event;
 use GlRequest;
 use MouseCursor;
+use PixelFormat;
 use native_monitor::NativeMonitorId;
 
 use gl_common;
@@ -386,6 +387,11 @@ impl Window {
     /// - On Linux, it must be checked at runtime.
     pub fn get_api(&self) -> Api {
         self.window.get_api()
+    }
+
+    /// Returns the pixel format of this window.
+    pub fn get_pixel_format(&self) -> PixelFormat {
+        self.window.get_pixel_format()
     }
 
     /// Create a window proxy for this window, that can be freely

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex, Once, ONCE_INIT};
 use Api;
 use CursorState;
 use GlRequest;
+use PixelFormat;
 
 pub use self::monitor::{MonitorID, get_available_monitors, get_primary_monitor};
 
@@ -730,6 +731,10 @@ impl Window {
     /// See the docs in the crate root file.
     pub fn get_api(&self) -> ::Api {
         ::Api::OpenGl
+    }
+
+    pub fn get_pixel_format(&self) -> PixelFormat {
+        unimplemented!();
     }
 
     pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {


### PR DESCRIPTION
cc @kvark

Only implemented on win32. The x11 implementation needs some work (creating a `PixelFormat` struct from a `FBConfig`), the android implementation will probably move to the new `egl` module created in #367, and the cocoa implementation needs to be done by someone that has a mac.
