### PR TITLE
Add mouse hiding and more cursors for Cocoa

### DIFF
--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -630,30 +630,29 @@ impl Window {
 
     pub fn set_cursor(&self, cursor: MouseCursor) {
         let cursor_name = match cursor {                
-            MouseCursor::Arrow => "arrowCursor",
+            MouseCursor::Arrow | MouseCursor::Default => "arrowCursor",
+            MouseCursor::Hand => "pointingHandCursor",
+            MouseCursor::Grabbing | MouseCursor::Grab => "closedHandCursor",
             MouseCursor::Text => "IBeamCursor",
-            MouseCursor::ContextMenu => "contextualMenuCursor",
+            MouseCursor::VerticalText => "IBeamCursorForVerticalLayout",
             MouseCursor::Copy => "dragCopyCursor",
-            MouseCursor::Crosshair => "crosshairCursor",
-            MouseCursor::Default => "arrowCursor",
-            MouseCursor::Grabbing => "openHandCursor",
-            MouseCursor::Hand | MouseCursor::Grab => "pointingHandCursor",
-            MouseCursor::NoDrop => "operationNotAllowedCursor",
-            MouseCursor::NotAllowed => "operationNotAllowedCursor",
             MouseCursor::Alias => "dragLinkCursor",
-            
-            
-            /// Resize cursors
-            MouseCursor::EResize | MouseCursor::NResize |
-            MouseCursor::NeResize | MouseCursor::NwResize |
-            MouseCursor::SResize | MouseCursor::SeResize |
-            MouseCursor::SwResize | MouseCursor::WResize |
-            MouseCursor::EwResize | MouseCursor::ColResize |
-            MouseCursor::NsResize | MouseCursor::RowResize |
-            MouseCursor::NwseResize | MouseCursor::NeswResize => "arrowCursor",
+            MouseCursor::NotAllowed | MouseCursor::NoDrop => "operationNotAllowedCursor",
+            MouseCursor::ContextMenu => "contextualMenuCursor",
+            MouseCursor::Crosshair => "crosshairCursor",
+            MouseCursor::EResize => "resizeRightCursor",
+            MouseCursor::NResize => "resizeUpCursor",
+            MouseCursor::WResize => "resizeLeftCursor",
+            MouseCursor::SResize => "resizeDownCursor",
+            MouseCursor::EwResize | MouseCursor::ColResize => "resizeLeftRightCursor",
+            MouseCursor::NsResize | MouseCursor::RowResize => "resizeUpDownCursor",
 
             /// TODO: Find appropriate OSX cursors
-             MouseCursor::Cell | MouseCursor::VerticalText | MouseCursor::NoneCursor |
+            MouseCursor::NeResize | MouseCursor::NwResize |
+            MouseCursor::SeResize | MouseCursor::SwResize |
+            MouseCursor::NwseResize | MouseCursor::NeswResize |
+
+            MouseCursor::Cell | MouseCursor::NoneCursor |
             MouseCursor::Wait | MouseCursor::Progress | MouseCursor::Help |
             MouseCursor::Move | MouseCursor::AllScroll | MouseCursor::ZoomIn |
             MouseCursor::ZoomOut => "arrowCursor",
@@ -668,7 +667,20 @@ impl Window {
     }
 
     pub fn set_cursor_state(&self, state: CursorState) -> Result<(), String> {
-        unimplemented!();
+        let cls = Class::get("NSCursor").unwrap();
+        match state {
+            CursorState::Normal => {
+                let _: () = unsafe { msg_send![cls, unhide] };
+                Ok(())
+            },
+            CursorState::Hide => {
+                let _: () = unsafe { msg_send![cls, hide] };
+                Ok(())
+            },
+            CursorState::Grab => {
+                Err("Mouse grabbing is unimplemented".to_string())
+            }
+        }
     }
 
     pub fn hidpi_factor(&self) -> f32 {


### PR DESCRIPTION
Mouse hiding is done by `[NSCursor hide/unhide]`. For progress on mouse grabbing see #226.

Also adds a few new cursors:
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/closed_hand.gif) `closedHandCursor`  for `Grabbing` and `Grab`
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/horizontal_cursor.png) `IBeamCursorForVerticalLayout`  for `VerticalText`
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/left.gif) `resizeLeftCursor` for `WResize`
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/up.gif) `resizeUpCursor` for `NResize`
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/right.gif) `resizeRightCursor` for `EResize`
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/down.gif) `resizeDownCursor` for `SResize`
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/leftright.gif) `resizeLeftRightCursor` for `EwResize` and `ColResize`
* ![](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/updown.gif) `resizeUpDownCursor` for `NsResize` and `RowResize`

Unfortunately these are the only system cursors available ([You can get them elsewhere](http://stackoverflow.com/a/21786835/3782657), but seems rather unstable) so we're left with the follow cursors defaulting to the arrow cursor (![arrow cursor](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSCursor_Class/Art/arrow.gif)): `NeResize`, `NwResize`, `SeResize`, `SwResize`, `NwseResize`, `NeswResize`, `Cell`, `NoneCursor`, `Wait`, `Progress`, `Help`, `Move`, `AllScroll`, `ZoomIn` and `ZoomOut`.