### PR TITLE
[Breaking change] Fix mouse wheel value on win32 and return a f64 instead of i32 in the MouseWheel event

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -275,7 +275,7 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                     self.window.delegate.state.pending_events.lock().unwrap().extend(events.into_iter());
                     event
                 },
-                NSScrollWheel           => { Some(MouseWheel(event.scrollingDeltaY() as i32)) },
+                NSScrollWheel           => { Some(MouseWheel(event.scrollingDeltaX() as f64, event.scrollingDeltaY() as f64)) },
                 _                       => { None },
             };
 

--- a/src/api/win32/callback.rs
+++ b/src/api/win32/callback.rs
@@ -114,8 +114,9 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
 
             let value = (wparam >> 16) as i16;
             let value = value as i32;
+            let value = value as f64 / winapi::WHEEL_DELTA as f64;
 
-            send_event(window, MouseWheel(value));
+            send_event(window, MouseWheel(0.0, value));
 
             0
         },

--- a/src/api/x11/mod.rs
+++ b/src/api/x11/mod.rs
@@ -240,11 +240,11 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                         ffi::Button2 => Some(Middle),
                         ffi::Button3 => Some(Right),
                         ffi::Button4 => {
-                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(1));
+                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(0.0, 1.0));
                             None
                         }
                         ffi::Button5 => {
-                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(-1));
+                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(0.0, -1.0));
                             None
                         }
                         _ => None

--- a/src/events.rs
+++ b/src/events.rs
@@ -25,9 +25,11 @@ pub enum Event {
     /// The parameter are the (x,y) coords in pixels relative to the top-left corner of the window.
     MouseMoved((i32, i32)),
 
+    /// Returns the horizontal and vertical mouse scrolling.
+    ///
     /// A positive value indicates that the wheel was rotated forward, away from the user;
-    ///  a negative value indicates that the wheel was rotated backward, toward the user.
-    MouseWheel(i32),
+    /// a negative value indicates that the wheel was rotated backward, toward the user.
+    MouseWheel(f64, f64),
 
     /// An event from the mouse has been received.
     MouseInput(ElementState, MouseButton),


### PR DESCRIPTION
Close #260 