### PR TITLE
Add a GlContext trait

### DIFF
--- a/src/api/cocoa/headless.rs
+++ b/src/api/cocoa/headless.rs
@@ -1,6 +1,7 @@
 use CreationError;
 use CreationError::OsError;
 use BuilderAttribs;
+use GlContext;
 use libc;
 use std::ptr;
 
@@ -56,8 +57,10 @@ impl HeadlessContext {
 
         Ok(headless)
     }
+}
 
-    pub unsafe fn make_current(&self) {
+impl GlContext for HeadlessContext {
+    unsafe fn make_current(&self) {
         self.context.makeCurrentContext();
 
         gl::GenFramebuffersEXT(1, &mut framebuffer);
@@ -76,11 +79,11 @@ impl HeadlessContext {
         }
     }
 
-    pub fn is_current(&self) -> bool {
+    fn is_current(&self) -> bool {
         unimplemented!()
     }
 
-    pub fn get_proc_address(&self, _addr: &str) -> *const () {
+    fn get_proc_address(&self, _addr: &str) -> *const () {
         let symbol_name: CFString = _addr.parse().unwrap();
         let framework_name: CFString = "com.apple.opengl".parse().unwrap();
         let framework = unsafe {
@@ -92,8 +95,15 @@ impl HeadlessContext {
         symbol as *const ()
     }
 
-    pub fn get_api(&self) -> ::Api {
+    fn swap_buffers(&self) {
+    }
+
+    fn get_api(&self) -> ::Api {
         ::Api::OpenGl
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        unimplemented!();
     }
 }
 

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -2,6 +2,7 @@
 
 use BuilderAttribs;
 use CreationError;
+use GlContext;
 use GlRequest;
 use PixelFormat;
 use Api;
@@ -156,8 +157,10 @@ impl Context {
             pixel_format: pixel_format,
         })
     }
+}
 
-    pub fn make_current(&self) {
+impl GlContext for Context {
+    unsafe fn make_current(&self) {
         let ret = unsafe {
             self.egl.MakeCurrent(self.display, self.surface, self.surface, self.context)
         };
@@ -167,23 +170,19 @@ impl Context {
         }
     }
 
-    pub fn get_pixel_format(&self) -> &PixelFormat {
-        &self.pixel_format
-    }
-
-    pub fn is_current(&self) -> bool {
+    fn is_current(&self) -> bool {
         unsafe { self.egl.GetCurrentContext() == self.context }
     }
 
-    pub fn get_proc_address(&self, addr: &str) -> *const () {
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void {
         let addr = CString::new(addr.as_bytes()).unwrap();
         let addr = addr.as_ptr();
         unsafe {
-            self.egl.GetProcAddress(addr) as *const ()
+            self.egl.GetProcAddress(addr) as *const _
         }
     }
 
-    pub fn swap_buffers(&self) {
+    fn swap_buffers(&self) {
         let ret = unsafe {
             self.egl.SwapBuffers(self.display, self.surface)
         };
@@ -193,8 +192,12 @@ impl Context {
         }
     }
 
-    pub fn get_api(&self) -> Api {
+    fn get_api(&self) -> Api {
         self.api
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        self.pixel_format.clone()
     }
 }
 

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -2,8 +2,10 @@
 
 use BuilderAttribs;
 use CreationError;
+use GlContext;
 use GlRequest;
 use Api;
+use PixelFormat;
 
 use libc;
 use std::ffi::CString;
@@ -140,34 +142,40 @@ impl Context {
             context: context,
         })
     }
+}
 
-    pub fn make_current(&self) {
-        let res = unsafe { ffi::glx::MakeCurrent(self.display as *mut _, self.window, self.context) };
+impl GlContext for Context {
+    unsafe fn make_current(&self) {
+        let res = ffi::glx::MakeCurrent(self.display as *mut _, self.window, self.context);
         if res == 0 {
             panic!("glx::MakeCurrent failed");
         }
     }
 
-    pub fn is_current(&self) -> bool {
+    fn is_current(&self) -> bool {
         unsafe { ffi::glx::GetCurrentContext() == self.context }
     }
 
-    pub fn get_proc_address(&self, addr: &str) -> *const () {
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void {
         let addr = CString::new(addr.as_bytes()).unwrap();
         let addr = addr.as_ptr();
         unsafe {
-            ffi::glx::GetProcAddress(addr as *const _) as *const ()
+            ffi::glx::GetProcAddress(addr as *const _) as *const _
         }
     }
 
-    pub fn swap_buffers(&self) {
+    fn swap_buffers(&self) {
         unsafe {
             ffi::glx::SwapBuffers(self.display as *mut _, self.window)
         }
     }
 
-    pub fn get_api(&self) -> ::Api {
+    fn get_api(&self) -> ::Api {
         ::Api::OpenGl
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        unimplemented!();
     }
 }
 

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -2,9 +2,12 @@
 
 extern crate osmesa_sys;
 
+use Api;
 use BuilderAttribs;
 use CreationError;
 use CreationError::OsError;
+use GlContext;
+use PixelFormat;
 use libc;
 use std::{mem, ptr};
 use std::ffi::CString;
@@ -43,7 +46,13 @@ impl OsMesaContext {
         (self.width, self.height)
     }
 
-    pub unsafe fn make_current(&self) {
+    // TODO: can we remove this without causing havoc?
+    pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {
+    }
+}
+
+impl GlContext for OsMesaContext {
+    unsafe fn make_current(&self) {
         let ret = osmesa_sys::OSMesaMakeCurrent(self.context,
             self.buffer.as_ptr() as *mut libc::c_void,
             0x1401, self.width as libc::c_int, self.height as libc::c_int);
@@ -53,23 +62,26 @@ impl OsMesaContext {
         }
     }
 
-    pub fn is_current(&self) -> bool {
+    fn is_current(&self) -> bool {
         unsafe { osmesa_sys::OSMesaGetCurrentContext() == self.context }
     }
 
-    pub fn get_proc_address(&self, addr: &str) -> *const () {
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void {
         unsafe {
             let c_str = CString::new(addr.as_bytes().to_vec()).unwrap();
             mem::transmute(osmesa_sys::OSMesaGetProcAddress(mem::transmute(c_str.as_ptr())))
         }
     }
 
-    /// See the docs in the crate root file.
-    pub fn get_api(&self) -> ::Api {
-        ::Api::OpenGl
+    fn swap_buffers(&self) {
     }
 
-    pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {
+    fn get_api(&self) -> Api {
+        Api::OpenGl
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        unimplemented!();
     }
 }
 

--- a/src/api/x11/mod.rs
+++ b/src/api/x11/mod.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex, Once, ONCE_INIT};
 
 use Api;
 use CursorState;
+use GlContext;
 use GlRequest;
 use PixelFormat;
 
@@ -674,38 +675,6 @@ impl Window {
         }
     }
 
-    pub unsafe fn make_current(&self) {
-        match self.x.context {
-            Context::Glx(ref ctxt) => ctxt.make_current(),
-            Context::Egl(ref ctxt) => ctxt.make_current(),
-            Context::None => {}
-        }
-    }
-
-    pub fn is_current(&self) -> bool {
-        match self.x.context {
-            Context::Glx(ref ctxt) => ctxt.is_current(),
-            Context::Egl(ref ctxt) => ctxt.is_current(),
-            Context::None => panic!()
-        }
-    }
-
-    pub fn get_proc_address(&self, addr: &str) -> *const () {
-        match self.x.context {
-            Context::Glx(ref ctxt) => ctxt.get_proc_address(addr),
-            Context::Egl(ref ctxt) => ctxt.get_proc_address(addr),
-            Context::None => ptr::null()
-        }
-    }
-
-    pub fn swap_buffers(&self) {
-        match self.x.context {
-            Context::Glx(ref ctxt) => ctxt.swap_buffers(),
-            Context::Egl(ref ctxt) => ctxt.swap_buffers(),
-            Context::None => {}
-        }
-    }
-
     pub fn platform_display(&self) -> *mut libc::c_void {
         self.x.display as *mut libc::c_void
     }
@@ -714,18 +683,6 @@ impl Window {
         unimplemented!()
     }
 
-    /// See the docs in the crate root file.
-    pub fn get_api(&self) -> ::Api {
-        match self.x.context {
-            Context::Glx(ref ctxt) => ctxt.get_api(),
-            Context::Egl(ref ctxt) => ctxt.get_api(),
-            Context::None => panic!()
-        }
-    }
-
-    pub fn get_pixel_format(&self) -> PixelFormat {
-        self.pixel_format.clone()
-    }
 
     pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {
     }
@@ -826,5 +783,51 @@ impl Window {
         }
 
         Ok(())
+    }
+}
+
+impl GlContext for Window {
+    unsafe fn make_current(&self) {
+        match self.x.context {
+            Context::Glx(ref ctxt) => ctxt.make_current(),
+            Context::Egl(ref ctxt) => ctxt.make_current(),
+            Context::None => {}
+        }
+    }
+
+    fn is_current(&self) -> bool {
+        match self.x.context {
+            Context::Glx(ref ctxt) => ctxt.is_current(),
+            Context::Egl(ref ctxt) => ctxt.is_current(),
+            Context::None => panic!()
+        }
+    }
+
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void {
+        match self.x.context {
+            Context::Glx(ref ctxt) => ctxt.get_proc_address(addr),
+            Context::Egl(ref ctxt) => ctxt.get_proc_address(addr),
+            Context::None => ptr::null()
+        }
+    }
+
+    fn swap_buffers(&self) {
+        match self.x.context {
+            Context::Glx(ref ctxt) => ctxt.swap_buffers(),
+            Context::Egl(ref ctxt) => ctxt.swap_buffers(),
+            Context::None => {}
+        }
+    }
+
+    fn get_api(&self) -> Api {
+        match self.x.context {
+            Context::Glx(ref ctxt) => ctxt.get_api(),
+            Context::Egl(ref ctxt) => ctxt.get_api(),
+            Context::None => panic!()
+        }
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        self.pixel_format.clone()
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -2,6 +2,8 @@ use Api;
 use BuilderAttribs;
 use CreationError;
 use GlRequest;
+use GlContext;
+use PixelFormat;
 
 use gl_common;
 use libc;
@@ -99,5 +101,31 @@ impl HeadlessContext {
 impl gl_common::GlFunctionsSource for HeadlessContext {
     fn get_proc_addr(&self, addr: &str) -> *const libc::c_void {
         self.get_proc_address(addr)
+    }
+}
+
+impl GlContext for HeadlessContext {
+    unsafe fn make_current(&self) {
+        self.make_current()
+    }
+
+    fn is_current(&self) -> bool {
+        self.is_current()
+    }
+
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void {
+        self.get_proc_address(addr)
+    }
+
+    fn swap_buffers(&self) {
+        self.swap_buffers()
+    }
+
+    fn get_api(&self) -> Api {
+        self.get_api()
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        self.get_pixel_format()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,34 @@ mod headless;
 #[cfg(feature = "window")]
 mod window;
 
+/// Trait that describes objects that have access to an OpenGL context.
+pub trait GlContext {
+    /// Sets the context as the current context.
+    unsafe fn make_current(&self);
+
+    /// Returns true if this context is the current one in this thread.
+    fn is_current(&self) -> bool;
+
+    /// Returns the address of an OpenGL function.
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void;
+
+    /// Swaps the buffers in case of double or triple buffering.
+    ///
+    /// You should call this function every time you have finished rendering, or the image
+    ///  may not be displayed on the screen.
+    ///
+    /// **Warning**: if you enabled vsync, this function will block until the next time the screen
+    /// is refreshed. However drivers can choose to override your vsync settings, which means that
+    /// you can't know in advance whether `swap_buffers` will block or not.
+    fn swap_buffers(&self);
+
+    /// Returns the OpenGL API being used.
+    fn get_api(&self) -> Api;
+
+    /// Returns the pixel format of the main framebuffer of the context.
+    fn get_pixel_format(&self) -> PixelFormat;
+}
+
 /// Error that can happen while creating a window or a headless renderer.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CreationError {

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -2,9 +2,13 @@
 
 pub use api::win32::*;
 
+use libc;
+
 use Api;
 use BuilderAttribs;
 use CreationError;
+use PixelFormat;
+use GlContext;
 
 ///
 pub struct HeadlessContext(Window);
@@ -14,20 +18,30 @@ impl HeadlessContext {
         builder.visible = false;
         Window::new(builder).map(|w| HeadlessContext(w))
     }
+}
 
-    pub unsafe fn make_current(&self) {
+impl GlContext for HeadlessContext {
+    unsafe fn make_current(&self) {
         self.0.make_current()
     }
 
-    pub fn is_current(&self) -> bool {
+    fn is_current(&self) -> bool {
         self.0.is_current()
     }
 
-    pub fn get_proc_address(&self, addr: &str) -> *const () {
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void {
         self.0.get_proc_address(addr)
     }
 
-    pub fn get_api(&self) -> Api {
+    fn swap_buffers(&self) {
+        self.0.swap_buffers()
+    }
+
+    fn get_api(&self) -> Api {
         self.0.get_api()
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        self.0.get_pixel_format()
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,6 +6,7 @@ use BuilderAttribs;
 use CreationError;
 use CursorState;
 use Event;
+use GlContext;
 use GlRequest;
 use MouseCursor;
 use PixelFormat;
@@ -428,6 +429,32 @@ impl gl_common::GlFunctionsSource for Window {
     }
 }
 
+impl GlContext for Window {
+    unsafe fn make_current(&self) {
+        self.make_current()
+    }
+
+    fn is_current(&self) -> bool {
+        self.is_current()
+    }
+
+    fn get_proc_address(&self, addr: &str) -> *const libc::c_void {
+        self.get_proc_address(addr)
+    }
+
+    fn swap_buffers(&self) {
+        self.swap_buffers()
+    }
+
+    fn get_api(&self) -> Api {
+        self.get_api()
+    }
+
+    fn get_pixel_format(&self) -> PixelFormat {
+        self.get_pixel_format()
+    }
+}
+
 /// Represents a thread safe subset of operations that can be called
 /// on a window. This structure can be safely cloned and sent between
 /// threads.
@@ -437,7 +464,6 @@ pub struct WindowProxy {
 }
 
 impl WindowProxy {
-
     /// Triggers a blocked event loop to wake up. This is
     /// typically called when another thread wants to wake
     /// up the blocked rendering thread to cause a refresh.


### PR DESCRIPTION
The `GlContext` trait contains all methods that are required to access an OpenGL context.
This doesn't break anything, because `Window` and `HeadlessContext` still implement the functions outside of traits.

Conflicts with #410 

cc #341 