### PR TITLE
Adding SWP_NOMOVE flag to prevent the window from moving to 0,0 when setting inner size on Windows 8

### DIFF
--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -197,7 +197,7 @@ impl Window {
 
         unsafe {
             user32::SetWindowPos(self.window.0, ptr::null_mut(), 0, 0, x as libc::c_int,
-                y as libc::c_int, winapi::SWP_NOZORDER | winapi::SWP_NOREPOSITION);
+                y as libc::c_int, winapi::SWP_NOZORDER | winapi::SWP_NOREPOSITION | winapi::SWP_NOMOVE);
             user32::UpdateWindow(self.window.0);
         }
     }


### PR DESCRIPTION
Hey tomaka, we spoke earlier on irc about this issue. I was able to reproduce it on my Windows 8 box. Adding in the flag SWP_NOMOVE solved the issue for me. I am submitting a pull request for consideration into fixing this issue for Windows 8+ for glutin. 