### PR TITLE
Remove the "headless" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
 script:
   - cargo build --verbose
-  - cargo test --no-run --verbose
+  - cargo test --verbose
   - cargo test --verbose --features "headless" --no-default-features
 
 os:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,9 @@ user32-sys = "0.1"
 kernel32-sys = "0.1"
 
 [target.i686-unknown-linux-gnu.dependencies]
-osmesa-sys = "*"
+osmesa-sys = "0.0.5"
 x11 = "*"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-osmesa-sys = "*"
+osmesa-sys = "0.0.5"
 x11 = "*"

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -1,6 +1,5 @@
 #![cfg(target_os = "macos")]
 
-#[cfg(feature = "headless")]
 pub use self::headless::HeadlessContext;
 
 use {CreationError, Event, MouseCursor, CursorState};
@@ -48,8 +47,6 @@ pub use self::monitor::{MonitorID, get_available_monitors, get_primary_monitor};
 
 mod monitor;
 mod event;
-
-#[cfg(feature = "headless")]
 mod headless;
 
 static mut shift_pressed: bool = false;

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -2,10 +2,8 @@
 
 pub use api::android::*;
 
-#[cfg(feature = "headless")]
 pub struct HeadlessContext(i32);
 
-#[cfg(feature = "headless")]
 impl HeadlessContext {
     /// See the docs in the crate root file.
     pub fn new(_builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
@@ -32,7 +30,5 @@ impl HeadlessContext {
     }
 }
 
-#[cfg(feature = "headless")]
 unsafe impl Send for HeadlessContext {}
-#[cfg(feature = "headless")]
 unsafe impl Sync for HeadlessContext {}

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -5,10 +5,8 @@ use GlContext;
 pub use api::emscripten::{Window, WindowProxy, MonitorID, get_available_monitors};
 pub use api::emscripten::{get_primary_monitor, WaitEventsIterator, PollEventsIterator};
 
-#[cfg(feature = "headless")]
 pub struct HeadlessContext(Window);
 
-#[cfg(feature = "headless")]
 impl HeadlessContext {
     /// See the docs in the crate root file.
     pub fn new(builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
@@ -16,7 +14,6 @@ impl HeadlessContext {
     }
 }
 
-#[cfg(feature = "headless")]
 impl GlContext for HeadlessContext {
     unsafe fn make_current(&self) {
         self.0.make_current()
@@ -43,7 +40,5 @@ impl GlContext for HeadlessContext {
     }
 }
 
-#[cfg(feature = "headless")]
 unsafe impl Send for HeadlessContext {}
-#[cfg(feature = "headless")]
 unsafe impl Sync for HeadlessContext {}


### PR DESCRIPTION
This feature existed in order to avoid having to link to OSMesa. Now that OSMesa is loaded though a shared library, it is no longer necessary.

The feature still exists for backward compatibility, but it has no effect and should be removed in 0.1.
