### PR TITLE
Continuation of wayland API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,15 +50,15 @@ kernel32-sys = "0.1"
 
 [target.i686-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
-wayland-client = "0.1.3"
+wayland-client = "0.1.4"
 x11-dl = "=1.0.1"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
-wayland-client = "0.1.3"
+wayland-client = "0.1.4"
 x11-dl = "=1.0.1"
 
 [target.arm-unknown-linux-gnueabihf.dependencies]
 osmesa-sys = "0.0.5"
-wayland-client = "0.1.3"
+wayland-client = "0.1.4"
 x11-dl = "=1.0.1"


### PR DESCRIPTION
Still not finished, but adding support for `WindowProxy::wakeup_event_loop()` and `MonitorID`, as well as stubbing `Window::get_position()` and `Window::set_position()`, which are not possible with the current wayland stable protocol.