### PR TITLE
implement get_platform_window() return for X11

### DIFF
--- a/src/api/x11/mod.rs
+++ b/src/api/x11/mod.rs
@@ -705,7 +705,7 @@ impl Window {
     }
 
     pub fn platform_window(&self) -> *mut libc::c_void {
-        unimplemented!()
+        self.x.window as *mut libc::c_void
     }
 
 


### PR DESCRIPTION
This was unimplemented, so I implemented it.