### PR TITLE
x11: Express directional mouse wheel ticks in the API

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -39,6 +39,7 @@ use std::ascii::AsciiExt;
 use std::ops::Deref;
 
 use events::Event::{Awakened, MouseInput, MouseMoved, ReceivedCharacter, KeyboardInput, MouseWheel, Closed};
+use events::MouseWheelMotion;
 use events::ElementState::{Pressed, Released};
 use events::MouseButton;
 use events;
@@ -275,7 +276,7 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                     self.window.delegate.state.pending_events.lock().unwrap().extend(events.into_iter());
                     event
                 },
-                NSScrollWheel           => { Some(MouseWheel(event.scrollingDeltaX() as f64, event.scrollingDeltaY() as f64)) },
+                NSScrollWheel           => { Some(MouseWheel(MouseWheelMotion::Delta(event.scrollingDeltaX() as f64, event.scrollingDeltaY() as f64))) },
                 _                       => { None },
             };
 

--- a/src/api/win32/callback.rs
+++ b/src/api/win32/callback.rs
@@ -111,12 +111,13 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
 
         winapi::WM_MOUSEWHEEL => {
             use events::Event::MouseWheel;
+            use events::MouseWheelMotion;
 
             let value = (wparam >> 16) as i16;
             let value = value as i32;
             let value = value as f64 / winapi::WHEEL_DELTA as f64;
 
-            send_event(window, MouseWheel(0.0, value));
+            send_event(window, MouseWheel(MouseWheelMotion::Delta(0.0, value)));
 
             0
         },

--- a/src/api/x11/mod.rs
+++ b/src/api/x11/mod.rs
@@ -234,6 +234,7 @@ impl<'a> Iterator for PollEventsIterator<'a> {
 
                 ffi::ButtonPress | ffi::ButtonRelease => {
                     use events::Event::{MouseInput, MouseWheel};
+                    use events::MouseWheelMotion;
                     use events::ElementState::{Pressed, Released};
                     use events::MouseButton::{Left, Right, Middle};
 
@@ -246,11 +247,11 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                         ffi::Button2 => Some(Middle),
                         ffi::Button3 => Some(Right),
                         ffi::Button4 => {
-                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(0.0, 1.0));
+                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(MouseWheelMotion::TickDown));
                             None
                         }
                         ffi::Button5 => {
-                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(0.0, -1.0));
+                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(MouseWheelMotion::TickUp));
                             None
                         }
                         _ => None

--- a/src/events.rs
+++ b/src/events.rs
@@ -26,10 +26,7 @@ pub enum Event {
     MouseMoved((i32, i32)),
 
     /// Returns the horizontal and vertical mouse scrolling.
-    ///
-    /// A positive value indicates that the wheel was rotated forward, away from the user;
-    /// a negative value indicates that the wheel was rotated backward, toward the user.
-    MouseWheel(f64, f64),
+    MouseWheel(MouseWheelMotion),
 
     /// An event from the mouse has been received.
     MouseInput(ElementState, MouseButton),
@@ -55,6 +52,16 @@ pub enum MouseButton {
     Right,
     Middle,
     Other(u8),
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub enum MouseWheelMotion {
+    /// A positive value indicates that the wheel was rotated forward, away from the user;
+    /// a negative value indicates that the wheel was rotated backward, toward the user.
+    Delta(i64, i64),
+
+    TickUp,
+    TickDown,
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
In X11, mouse wheel ticks are just direction button presses. Previously
the code represented that as a scroll delta of 1. It is really up to the
application to process mouse wheel ticks though.

Fixes #420.