### PR TITLE
Switch to the official crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ version = "0"
 
 [target.x86_64-apple-darwin.dependencies]
 objc = "0.1"
-glutin_cocoa = "0"
-glutin_core_graphics = "0"
-glutin_core_foundation = "0"
+cocoa = "0"
+core-foundation = "0"
+core-graphics = "0"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "~0.1.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ extern crate cocoa;
 #[cfg(target_os = "macos")]
 extern crate core_foundation;
 #[cfg(target_os = "macos")]
-extern crate glutin_core_graphics as core_graphics;
+extern crate core_graphics;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 extern crate x11_dl;
 


### PR DESCRIPTION
cocoa, core-foundation, and core-graphics are now on crates.io.