### PR TITLE
Specify scroll deltas as either line or pixel-based

### DIFF
--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -17,7 +17,7 @@ fn main() { println!("This example requires glutin to be compiled with the `wind
 #[cfg(feature = "window")]
 fn main() {
     
-    let mut window = glutin::Window::new().unwrap();
+    let window = glutin::Window::new().unwrap();
     window.set_title("A fantastic window!");   
     unsafe { window.make_current() };
 

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -276,8 +276,12 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                     event
                 },
                 NSScrollWheel => {
-                    use events::MouseScrollDelta::PixelDelta;
-                    let delta = PixelDelta(event.scrollingDeltaX() as f32, event.scrollingDeltaY() as f32);
+                    use events::MouseScrollDelta::{LineDelta, PixelDelta};
+                    let delta = if event.hasPreciseScrollingDeltas() == YES {
+                        PixelDelta(event.scrollingDeltaX() as f32, event.scrollingDeltaY() as f32)
+                    } else {
+                        LineDelta(event.scrollingDeltaX() as f32, event.scrollingDeltaY() as f32)
+                    };
                     Some(MouseWheel(delta))
                 },
                 _                       => { None },

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -275,7 +275,11 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                     self.window.delegate.state.pending_events.lock().unwrap().extend(events.into_iter());
                     event
                 },
-                NSScrollWheel           => { Some(MouseWheel(event.scrollingDeltaX() as f64, event.scrollingDeltaY() as f64)) },
+                NSScrollWheel => {
+                    use events::MouseScrollDelta::PixelDelta;
+                    let delta = PixelDelta(event.scrollingDeltaX() as f32, event.scrollingDeltaY() as f32);
+                    Some(MouseWheel(delta))
+                },
                 _                       => { None },
             };
 

--- a/src/api/win32/callback.rs
+++ b/src/api/win32/callback.rs
@@ -112,12 +112,13 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
 
         winapi::WM_MOUSEWHEEL => {
             use events::Event::MouseWheel;
+            use events::MouseScrollDelta::LineDelta;
 
             let value = (wparam >> 16) as i16;
             let value = value as i32;
-            let value = value as f64 / winapi::WHEEL_DELTA as f64;
+            let value = value as f32 / winapi::WHEEL_DELTA as f32;
 
-            send_event(window, MouseWheel(0.0, value));
+            send_event(window, MouseWheel(LineDelta(0.0, value)));
 
             0
         },

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -219,6 +219,7 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                     use events::Event::{MouseInput, MouseWheel};
                     use events::ElementState::{Pressed, Released};
                     use events::MouseButton::{Left, Right, Middle};
+                    use events::MouseScrollDelta::{LineDelta};
 
                     let event: &ffi::XButtonEvent = unsafe { mem::transmute(&xev) };
 
@@ -229,11 +230,13 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                         ffi::Button2 => Some(Middle),
                         ffi::Button3 => Some(Right),
                         ffi::Button4 => {
-                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(0.0, 1.0));
+                            let delta = LineDelta(0.0, 1.0);
+                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(delta));
                             None
                         }
                         ffi::Button5 => {
-                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(0.0, -1.0));
+                            let delta = LineDelta(0.0, -1.0);
+                            self.window.pending_events.lock().unwrap().push_back(MouseWheel(delta));
                             None
                         }
                         _ => None

--- a/src/events.rs
+++ b/src/events.rs
@@ -63,7 +63,7 @@ pub enum MouseScrollDelta {
 	/// and vertical directions.
 	///
 	/// Positive values indicate movement forward
-	/// (away from the user) or righwards.
+	/// (away from the user) or rightwards.
 	LineDelta(f32, f32),
 	/// Amount in pixels to scroll in the horizontal and
 	/// vertical direction.

--- a/src/events.rs
+++ b/src/events.rs
@@ -25,10 +25,7 @@ pub enum Event {
     /// The parameter are the (x,y) coords in pixels relative to the top-left corner of the window.
     MouseMoved((i32, i32)),
 
-    /// A mouse wheel or touchpad scroll occurred. Depending on whether the 
-    ///
-    /// A positive value indicates that the wheel was rotated forward, away from the user;
-    /// a negative value indicates that the wheel was rotated backward, toward the user.
+    /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel(MouseScrollDelta),
 
     /// An event from the mouse has been received.

--- a/src/events.rs
+++ b/src/events.rs
@@ -25,11 +25,11 @@ pub enum Event {
     /// The parameter are the (x,y) coords in pixels relative to the top-left corner of the window.
     MouseMoved((i32, i32)),
 
-    /// Returns the horizontal and vertical mouse scrolling.
+    /// A mouse wheel or touchpad scroll occurred. Depending on whether the 
     ///
     /// A positive value indicates that the wheel was rotated forward, away from the user;
     /// a negative value indicates that the wheel was rotated backward, toward the user.
-    MouseWheel(f64, f64),
+    MouseWheel(MouseScrollDelta),
 
     /// An event from the mouse has been received.
     MouseInput(ElementState, MouseButton),
@@ -55,6 +55,23 @@ pub enum MouseButton {
     Right,
     Middle,
     Other(u8),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MouseScrollDelta {
+	/// Amount in lines or rows to scroll in the horizontal
+	/// and vertical directions.
+	///
+	/// Positive values indicate movement forward
+	/// (away from the user) or righwards.
+	LineDelta(f32, f32),
+	/// Amount in pixels to scroll in the horizontal and
+	/// vertical direction.
+	///
+	/// Scroll events are expressed as a PixelDelta if
+	/// supported by the device (eg. a touchpad) and
+	/// platform.
+	PixelDelta(f32, f32)
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]


### PR DESCRIPTION
This PR implements @mrobinson's proposal at https://github.com/tomaka/glutin/pull/451#issuecomment-102311877 for representing scroll deltas in either lines/chunks/rows or pixels, depending on what is supported by the underlying platform and device. 
Windows and X11 currently report deltas in lines, OS X in pixels. X11 could support pixel deltas in future using the XInput2 API which is what GTK uses for high-res scroll events.

It is up to the app to interpret line-deltas appropriately. In Firefox for example, the maximum height of a frame's main font is used as the line height. Apple's documentation specifies that on devices that don't support 'precise' scrolling deltas, the delta should be interpreted as lines or rows (in a list of items). Windows documentation uses the slightly more vague 'chunks'.

This still needs tests. I'm posting the PR to get feedback on the proposed API and namings.