### PR TITLE
Make legacy functions crash on osx core contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ version = "0"
 
 [target.x86_64-apple-darwin.dependencies]
 objc = "0.1"
+cgl = "0"
 cocoa = "0"
 core-foundation = "0"
 core-graphics = "0"

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -17,7 +17,7 @@ fn main() { println!("This example requires glutin to be compiled with the `wind
 #[cfg(feature = "window")]
 fn main() {
     
-    let window = glutin::Window::new().unwrap();
+    let window = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility).build().unwrap();
     window.set_title("A fantastic window!");   
     unsafe { window.make_current() };
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -35,6 +35,7 @@ fn main() {
     };
 
     let window = glutin::WindowBuilder::new()
+        .with_gl_profile(glutin::GlProfile::Compatibility)
         .with_title("Hello world!".to_string())
         .with_fullscreen(monitor)
         .build()

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -16,7 +16,7 @@ fn main() { println!("This example requires glutin to be compiled with the `wind
 
 #[cfg(feature = "window")]
 fn main() {
-    let window = glutin::Window::new().unwrap();
+    let window = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility).build().unwrap();
     window.set_title("glutin - Cursor grabbing test");
     unsafe { window.make_current() };
 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -16,9 +16,9 @@ fn main() { println!("This example requires glutin to be compiled with the `wind
 
 #[cfg(feature = "window")]
 fn main() {
-    let window1 = glutin::Window::new().unwrap();
-    let window2 = glutin::Window::new().unwrap();
-    let window3 = glutin::Window::new().unwrap();
+    let window1 = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility).build().unwrap();
+    let window2 = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility).build().unwrap();
+    let window3 = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility).build().unwrap();
 
     let t1 = thread::spawn(move || {
         run(window1, (0.0, 1.0, 0.0, 1.0));

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -19,7 +19,9 @@ fn resize_callback(width: u32, height: u32) {
 
 #[cfg(feature = "window")]
 fn main() {
-    let mut window = glutin::WindowBuilder::new().with_decorations(false).with_transparency(true)
+    let mut window = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility)
+                                                 .with_decorations(false)
+                                                 .with_transparency(true)
                                                  .build().unwrap();
     window.set_title("A fantastic window!");
     window.set_window_resize_callback(Some(resize_callback as fn(u32, u32)));

--- a/examples/vsync.rs
+++ b/examples/vsync.rs
@@ -23,7 +23,9 @@ fn main() {
     println!("Vsync example. This example may panic if your driver or your system forces \
               you out of vsync. This is intended when `build_strict` is used.");
 
-    let mut window = glutin::WindowBuilder::new().with_vsync().build_strict().unwrap();
+    let mut window = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility)
+                                                 .with_vsync()
+                                                 .build_strict().unwrap();
     window.set_window_resize_callback(Some(resize_callback as fn(u32, u32)));
     unsafe { window.make_current() };
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -19,7 +19,7 @@ fn resize_callback(width: u32, height: u32) {
 
 #[cfg(feature = "window")]
 fn main() {
-    let mut window = glutin::Window::new().unwrap();
+    let mut window = glutin::WindowBuilder::new().with_gl_profile(glutin::GlProfile::Compatibility).build().unwrap();
     window.set_title("A fantastic window!");
     window.set_window_resize_callback(Some(resize_callback as fn(u32, u32)));
     unsafe { window.make_current() };

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -17,6 +17,10 @@ use native_monitor::NativeMonitorId;
 use objc::runtime::{Class, Object, Sel, BOOL, YES, NO};
 use objc::declare::ClassDecl;
 
+use cgl;
+use cgl::{CGLEnable, kCGLCECrashOnRemovedFunctions, CGLSetParameter, kCGLCPSurfaceOpacity};
+use cgl::CGLContextObj as CGL_CGLContextObj;
+
 use cocoa::base::{id, nil};
 use cocoa::foundation::{NSAutoreleasePool, NSDate, NSDefaultRunLoopMode, NSPoint, NSRect, NSSize, 
                         NSString, NSUInteger}; 
@@ -571,6 +575,8 @@ impl Window {
                     cxt.setView_(view);
                     let value = if builder.vsync { 1 } else { 0 };
                     cxt.setValues_forParameter_(&value, NSOpenGLContextParameter::NSOpenGLCPSwapInterval);
+
+                    CGLEnable(cxt.CGLContextObj(), kCGLCECrashOnRemovedFunctions);
 
                     Ok((cxt, pf))
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ extern crate dwmapi;
 #[macro_use]
 extern crate objc;
 #[cfg(target_os = "macos")]
+extern crate cgl;
+#[cfg(target_os = "macos")]
 extern crate cocoa;
 #[cfg(target_os = "macos")]
 extern crate core_foundation;


### PR DESCRIPTION
Default behaviour is to just ignore the functions.