### PR TITLE
Handle errors from MakeCurrent and SwapBuffers

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -15,6 +15,7 @@ use std::collections::VecDeque;
 
 use Api;
 use BuilderAttribs;
+use ContextError;
 use CursorState;
 use GlContext;
 use GlRequest;
@@ -213,7 +214,7 @@ unsafe impl Send for Window {}
 unsafe impl Sync for Window {}
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.context.make_current()
     }
 
@@ -225,7 +226,7 @@ impl GlContext for Window {
         self.context.get_proc_address(addr)
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         self.context.swap_buffers()
     }
 

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -6,6 +6,7 @@ use api::osmesa::{OsMesaContext, OsMesaCreationError};
 
 use Api;
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use Event;
 use GlContext;
@@ -209,7 +210,7 @@ impl Window {
 }
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.opengl.make_current()
     }
 
@@ -221,7 +222,7 @@ impl GlContext for Window {
         self.opengl.get_proc_address(addr)
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         unsafe {
             let canvas = (self.libcaca.caca_get_canvas)(self.display);
             let width = (self.libcaca.caca_get_canvas_width)(canvas);
@@ -235,6 +236,8 @@ impl GlContext for Window {
                                               buffer.as_ptr() as *const _);
             (self.libcaca.caca_refresh_display)(self.display);
         };
+
+        Ok(())
     }
 
     fn get_api(&self) -> Api {

--- a/src/api/cocoa/headless.rs
+++ b/src/api/cocoa/headless.rs
@@ -1,3 +1,4 @@
+use ContextError;
 use CreationError;
 use CreationError::OsError;
 use BuilderAttribs;
@@ -61,7 +62,7 @@ impl HeadlessContext {
 }
 
 impl GlContext for HeadlessContext {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.context.makeCurrentContext();
 
         gl::GenFramebuffersEXT(1, &mut framebuffer);
@@ -78,6 +79,8 @@ impl GlContext for HeadlessContext {
         if status != gl::FRAMEBUFFER_COMPLETE_EXT {
             panic!("Error while creating the framebuffer");
         }
+
+        Ok(())
     }
 
     fn is_current(&self) -> bool {
@@ -96,7 +99,8 @@ impl GlContext for HeadlessContext {
         symbol as *const libc::c_void
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
+        Ok(())
     }
 
     fn get_api(&self) -> ::Api {

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -8,6 +8,7 @@ use libc;
 
 use Api;
 use BuilderAttribs;
+use ContextError;
 use GlContext;
 use GlProfile;
 use GlRequest;
@@ -760,9 +761,10 @@ impl Window {
 }
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         let _: () = msg_send![*self.context, update];
         self.context.makeCurrentContext();
+        Ok(())
     }
 
     fn is_current(&self) -> bool {
@@ -789,8 +791,9 @@ impl GlContext for Window {
         symbol as *const _
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         unsafe { self.context.flushBuffer(); }
+        Ok(())
     }
 
     fn get_api(&self) -> ::Api {

--- a/src/api/emscripten/mod.rs
+++ b/src/api/emscripten/mod.rs
@@ -5,6 +5,7 @@ use libc;
 use {Event, BuilderAttribs, CreationError, MouseCursor};
 use Api;
 use PixelFormat;
+use ContextError;
 use GlContext;
 
 use std::collections::VecDeque;
@@ -191,9 +192,10 @@ impl Window {
 }
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         // TOOD: check if == EMSCRIPTEN_RESULT
         ffi::emscripten_webgl_make_context_current(self.context);
+        Ok(())
     }
 
     fn is_current(&self) -> bool {
@@ -209,10 +211,9 @@ impl GlContext for Window {
         }
     }
 
-    fn swap_buffers(&self) {
-        unsafe {
-            ffi::emscripten_sleep(1);   // FIXME: 
-        }
+    fn swap_buffers(&self) -> Result<(), ContextError> {
+        unsafe { ffi::emscripten_sleep(1); }  // FIXME:  
+        Ok(())
     }
 
     fn get_api(&self) -> Api {

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(all(target_os = "linux", feature = "window"))]
 
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use GlContext;
 use GlProfile;
@@ -139,11 +140,13 @@ impl Context {
 }
 
 impl GlContext for Context {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
+        // TODO: glutin needs some internal changes for proper error recovery
         let res = self.glx.MakeCurrent(self.display as *mut _, self.window, self.context);
         if res == 0 {
             panic!("glx::MakeCurrent failed");
         }
+        Ok(())
     }
 
     fn is_current(&self) -> bool {
@@ -158,10 +161,10 @@ impl GlContext for Context {
         }
     }
 
-    fn swap_buffers(&self) {
-        unsafe {
-            self.glx.SwapBuffers(self.display as *mut _, self.window)
-        }
+    fn swap_buffers(&self) -> Result<(), ContextError> {
+        // TODO: glutin needs some internal changes for proper error recovery
+        unsafe { self.glx.SwapBuffers(self.display as *mut _, self.window); }
+        Ok(())
     }
 
     fn get_api(&self) -> ::Api {

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -4,6 +4,7 @@ extern crate osmesa_sys;
 
 use Api;
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use GlContext;
 use PixelFormat;
@@ -67,14 +68,18 @@ impl OsMesaContext {
 }
 
 impl GlContext for OsMesaContext {
-    unsafe fn make_current(&self) {
-        let ret = osmesa_sys::OSMesaMakeCurrent(self.context,
-            self.buffer.as_ptr() as *mut libc::c_void,
-            0x1401, self.width as libc::c_int, self.height as libc::c_int);
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
+        let ret = osmesa_sys::OSMesaMakeCurrent(self.context, self.buffer.as_ptr()
+                                                as *mut libc::c_void, 0x1401, self.width
+                                                as libc::c_int, self.height as libc::c_int);
 
+        // an error can only happen in case of invalid parameter, which would indicate a bug
+        // in glutin
         if ret == 0 {
-            panic!("OSMesaMakeCurrent failed")
+            panic!("OSMesaMakeCurrent failed");
         }
+
+        Ok(())
     }
 
     fn is_current(&self) -> bool {
@@ -88,7 +93,8 @@ impl GlContext for OsMesaContext {
         }
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
+        Ok(())
     }
 
     fn get_api(&self) -> Api {

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -9,6 +9,7 @@ use api::dlopen;
 use api::egl::Context as EglContext;
 
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use Event;
 use PixelFormat;
@@ -282,8 +283,7 @@ impl Window {
 }
 
 impl GlContext for Window {
-
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.context.make_current()
     }
 
@@ -295,7 +295,7 @@ impl GlContext for Window {
         self.context.get_proc_address(addr)
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         self.context.swap_buffers()
     }
 

--- a/src/api/wgl/mod.rs
+++ b/src/api/wgl/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(any(target_os = "windows"))]
 
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use GlContext;
 use GlRequest;
@@ -156,9 +157,12 @@ impl Context {
 }
 
 impl GlContext for Context {
-    unsafe fn make_current(&self) {
-        // TODO: check return value
-        gl::wgl::MakeCurrent(self.hdc as *const _, self.context.0 as *const _);
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
+        if gl::wgl::MakeCurrent(self.hdc as *const _, self.context.0 as *const _) != 0 {
+            Ok(())
+        } else {
+            Err(ContextError::IoError(io::Error::last_os_error()))
+        }
     }
 
     fn is_current(&self) -> bool {
@@ -176,9 +180,11 @@ impl GlContext for Context {
         }
     }
 
-    fn swap_buffers(&self) {
-        unsafe {
-            gdi32::SwapBuffers(self.hdc);
+    fn swap_buffers(&self) -> Result<(), ContextError> {
+        if unsafe { gdi32::SwapBuffers(self.hdc) } != 0 {
+            Ok(())
+        } else {
+            Err(ContextError::IoError(io::Error::last_os_error()))
         }
     }
 

--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -11,6 +11,7 @@ use std::sync::{
 };
 use std::sync::mpsc::Receiver;
 use libc;
+use ContextError;
 use {CreationError, Event, MouseCursor};
 use CursorState;
 use GlContext;
@@ -315,7 +316,7 @@ impl Window {
 }
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         match self.context {
             Context::Wgl(ref c) => c.make_current(),
             Context::Egl(ref c) => c.make_current(),
@@ -336,7 +337,7 @@ impl GlContext for Window {
         }
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         match self.context {
             Context::Wgl(ref c) => c.swap_buffers(),
             Context::Egl(ref c) => c.swap_buffers(),

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -9,6 +9,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use Api;
+use ContextError;
 use CursorState;
 use GlContext;
 use GlRequest;
@@ -800,11 +801,11 @@ impl Window {
 }
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         match self.x.context {
             Context::Glx(ref ctxt) => ctxt.make_current(),
             Context::Egl(ref ctxt) => ctxt.make_current(),
-            Context::None => {}
+            Context::None => Ok(())
         }
     }
 
@@ -824,11 +825,11 @@ impl GlContext for Window {
         }
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         match self.x.context {
             Context::Glx(ref ctxt) => ctxt.swap_buffers(),
             Context::Egl(ref ctxt) => ctxt.swap_buffers(),
-            Context::None => {}
+            Context::None => Ok(())
         }
     }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,5 +1,6 @@
 use Api;
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use GlRequest;
 use GlContext;
@@ -69,7 +70,7 @@ impl HeadlessContext {
     /// Creates a new OpenGL context
     /// Sets the context as the current context.
     #[inline]
-    pub unsafe fn make_current(&self) {
+    pub unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.context.make_current()
     }
     
@@ -105,7 +106,7 @@ impl gl_common::GlFunctionsSource for HeadlessContext {
 }
 
 impl GlContext for HeadlessContext {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.context.make_current()
     }
 
@@ -117,7 +118,7 @@ impl GlContext for HeadlessContext {
         self.context.get_proc_address(addr)
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         self.context.swap_buffers()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub use window::{AvailableMonitorsIter, MonitorID, get_available_monitors, get_p
 #[cfg(feature = "window")]
 pub use native_monitor::NativeMonitorId;
 
+use std::io;
+
 mod api;
 mod platform;
 mod events;
@@ -73,7 +75,7 @@ mod window;
 /// Trait that describes objects that have access to an OpenGL context.
 pub trait GlContext {
     /// Sets the context as the current context.
-    unsafe fn make_current(&self);
+    unsafe fn make_current(&self) -> Result<(), ContextError>;
 
     /// Returns true if this context is the current one in this thread.
     fn is_current(&self) -> bool;
@@ -84,12 +86,12 @@ pub trait GlContext {
     /// Swaps the buffers in case of double or triple buffering.
     ///
     /// You should call this function every time you have finished rendering, or the image
-    ///  may not be displayed on the screen.
+    /// may not be displayed on the screen.
     ///
     /// **Warning**: if you enabled vsync, this function will block until the next time the screen
     /// is refreshed. However drivers can choose to override your vsync settings, which means that
     /// you can't know in advance whether `swap_buffers` will block or not.
-    fn swap_buffers(&self);
+    fn swap_buffers(&self) -> Result<(), ContextError>;
 
     /// Returns the OpenGL API being used.
     fn get_api(&self) -> Api;
@@ -124,6 +126,13 @@ impl std::error::Error for CreationError {
     fn description(&self) -> &str {
         self.to_string()
     }
+}
+
+/// Error that can happen when manipulating an OpenGL context.
+#[derive(Debug)]
+pub enum ContextError {
+    IoError(io::Error),
+    ContextLost,
 }
 
 /// All APIs related to OpenGL that you can possibly get while using glutin.

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -2,6 +2,8 @@
 
 pub use api::android::*;
 
+use ContextError;
+
 pub struct HeadlessContext(i32);
 
 impl HeadlessContext {
@@ -11,7 +13,7 @@ impl HeadlessContext {
     }
 
     /// See the docs in the crate root file.
-    pub unsafe fn make_current(&self) {
+    pub unsafe fn make_current(&self) -> Result<(), ContextError> {
         unimplemented!()
     }
 

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -1,5 +1,6 @@
 #![cfg(target_os = "emscripten")]
 
+use ContextError;
 use GlContext;
 
 pub use api::emscripten::{Window, WindowProxy, MonitorID, get_available_monitors};
@@ -15,7 +16,7 @@ impl HeadlessContext {
 }
 
 impl GlContext for HeadlessContext {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.0.make_current()
     }
 
@@ -27,7 +28,7 @@ impl GlContext for HeadlessContext {
         self.0.get_proc_address(addr)
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         self.0.swap_buffers()
     }
 

--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -7,6 +7,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use CursorState;
 use Event;
@@ -289,7 +290,7 @@ impl Window {
 }
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         match self {
             &Window::X(ref w) => w.make_current(),
             &Window::Wayland(ref w) => w.make_current()
@@ -310,7 +311,7 @@ impl GlContext for Window {
         }
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         match self {
             &Window::X(ref w) => w.swap_buffers(),
             &Window::Wayland(ref w) => w.swap_buffers()

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -2,6 +2,7 @@
 
 use Api;
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use GlContext;
 use PixelFormat;
@@ -37,7 +38,7 @@ impl HeadlessContext {
 
 impl GlContext for HeadlessContext {
     #[inline]
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.0.make_current()
     }
 
@@ -52,7 +53,7 @@ impl GlContext for HeadlessContext {
     }
 
     #[inline]
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         self.0.swap_buffers()
     }
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -6,6 +6,7 @@ use libc;
 
 use Api;
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use PixelFormat;
 use GlContext;
@@ -21,7 +22,7 @@ impl HeadlessContext {
 }
 
 impl GlContext for HeadlessContext {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.0.make_current()
     }
 
@@ -33,7 +34,7 @@ impl GlContext for HeadlessContext {
         self.0.get_proc_address(addr)
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         self.0.swap_buffers()
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -3,6 +3,7 @@ use std::default::Default;
 
 use Api;
 use BuilderAttribs;
+use ContextError;
 use CreationError;
 use CursorState;
 use Event;
@@ -339,7 +340,7 @@ impl Window {
 
     /// Sets the context as the current context.
     #[inline]
-    pub unsafe fn make_current(&self) {
+    pub unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.window.make_current()
     }
 
@@ -366,7 +367,7 @@ impl Window {
     /// is refreshed. However drivers can choose to override your vsync settings, which means that
     /// you can't know in advance whether `swap_buffers` will block or not.
     #[inline]
-    pub fn swap_buffers(&self) {
+    pub fn swap_buffers(&self) -> Result<(), ContextError> {
         self.window.swap_buffers()
     }
 
@@ -449,7 +450,7 @@ impl gl_common::GlFunctionsSource for Window {
 }
 
 impl GlContext for Window {
-    unsafe fn make_current(&self) {
+    unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.make_current()
     }
 
@@ -461,7 +462,7 @@ impl GlContext for Window {
         self.get_proc_address(addr)
     }
 
-    fn swap_buffers(&self) {
+    fn swap_buffers(&self) -> Result<(), ContextError> {
         self.swap_buffers()
     }
 


### PR DESCRIPTION
`MakeCurrent` and `SwapBuffers` can legitimately produce errors in some situations.
This is especially true for context loss errors on embedded platforms.
