### PR TITLE
Add dependencies lines for MSVC.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,13 @@ user32-sys = "~0.1.1"
 kernel32-sys = "0.1"
 dwmapi-sys = "0.1"
 
+[target.x86_64-pc-windows-msvc.dependencies]
+winapi = "~0.1.18"
+gdi32-sys = "0.1"
+user32-sys = "~0.1.1"
+kernel32-sys = "0.1"
+dwmapi-sys = "0.1"
+
 [target.i686-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = "0.1.6"


### PR DESCRIPTION
This adds yet another copy of the windows dependency lines - this time for the 64-bit MSVC target.

I've tested this with the first piston example (and I get the spinning red square) - so it seems like this is all that's needed.