### PR TITLE
Makes sure that the pixel format has the same multisampling settings as the requirements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,8 +398,15 @@ impl<'a> BuilderAttribs<'a> {
                 continue;
             }
 
-            if self.multisampling.is_some() && format.multisampling.is_none() {
-                continue;
+            if let Some(req_ms) = self.multisampling {
+                match format.multisampling {
+                    Some(val) if val >= req_ms => (),
+                    _ => continue
+                }
+            } else {
+                if format.multisampling.is_some() {
+                    continue;
+                }
             }
 
             if let Some(srgb) = self.srgb {


### PR DESCRIPTION
Fix #492 

Two changes compared to now:
 - Ensures that the pixel format has multisampling disabled if the user doesn't want it.
 - Ensures that the pixel format has at least the same multisampling level as the requirement.
