### PR TITLE
[0.3] DroppedFile event for Win32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ core-graphics = "0"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "~0.1.18"
+shell32-sys = "0.1"
 gdi32-sys = "0.1"
 user32-sys = "~0.1.1"
 kernel32-sys = "0.1"
@@ -46,6 +47,7 @@ dwmapi-sys = "0.1"
 
 [target.x86_64-pc-windows-gnu.dependencies]
 winapi = "~0.1.18"
+shell32-sys = "0.1"
 gdi32-sys = "0.1"
 user32-sys = "~0.1.1"
 kernel32-sys = "0.1"
@@ -53,6 +55,7 @@ dwmapi-sys = "0.1"
 
 [target.x86_64-pc-windows-msvc.dependencies]
 winapi = "~0.1.18"
+shell32-sys = "0.1"
 gdi32-sys = "0.1"
 user32-sys = "~0.1.1"
 kernel32-sys = "0.1"

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -133,7 +133,8 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
             style | winapi::WS_VISIBLE
         };
 
-        let handle = user32::CreateWindowExW(ex_style, class_name.as_ptr(),
+        let handle = user32::CreateWindowExW(ex_style | winapi::WS_EX_ACCEPTFILES,
+            class_name.as_ptr(),
             title.as_ptr() as winapi::LPCWSTR,
             style | winapi::WS_CLIPSIBLINGS | winapi::WS_CLIPCHILDREN,
             x.unwrap_or(winapi::CW_USEDEFAULT), y.unwrap_or(winapi::CW_USEDEFAULT),

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,6 @@
-#[derive(Clone, Debug, Copy)]
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
 pub enum Event {
     /// The size of the window has changed.
     Resized(u32, u32),
@@ -8,6 +10,9 @@ pub enum Event {
 
     /// The window has been closed.
     Closed,
+
+    /// A file has been dropped into the window.
+    DroppedFile(PathBuf),
 
     /// The window received a unicode character.
     ReceivedCharacter(char),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ extern crate winapi;
 #[cfg(target_os = "windows")]
 extern crate kernel32;
 #[cfg(target_os = "windows")]
+extern crate shell32;
+#[cfg(target_os = "windows")]
 extern crate gdi32;
 #[cfg(target_os = "windows")]
 extern crate user32;


### PR DESCRIPTION
cc #496
**Breaking**, `Event` is not `Copy` anymore.