### PR TITLE
Split creating an EGL context in two parts

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -111,8 +111,8 @@ impl Window {
             return Err(OsError(format!("Android's native window is null")));
         }
 
-        let context = try!(EglContext::new(egl::ffi::egl::Egl, &builder, None,
-                                           native_window as *const _));
+        let context = try!(EglContext::new(egl::ffi::egl::Egl, &builder, None)
+                                                .and_then(|p| p.finish(native_window as *const _)));
 
         let (tx, rx) = channel();
         android_glue::add_sender(tx);

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -169,9 +169,9 @@ impl Window {
             try!(EglContext::new(
                 egl,
                 &builder,
-                Some(wayland_context.display.ptr() as *const _),
-                (*shell_surface).ptr() as *const _
-            ))
+                Some(wayland_context.display.ptr() as *const _))
+                .and_then(|p| p.finish((*shell_surface).ptr() as *const _))
+            )
         };
 
         let events = Arc::new(Mutex::new(VecDeque::new()));

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -177,8 +177,8 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
                     unsafe { kernel32::GetProcAddress(dll, name.as_ptr()) as *const libc::c_void }
                 });
 
-                if let Ok(c) = EglContext::new(egl, &builder, Some(ptr::null()),
-                                               real_window.0)
+                if let Ok(c) = EglContext::new(egl, &builder, Some(ptr::null()))
+                                                              .and_then(|p| p.finish(real_window.0))
                 {
                     Context::Egl(c)
 

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -572,14 +572,14 @@ impl Window {
                     Context::Glx(try!(GlxContext::new(glx.clone(), builder, display.display, window,
                                                       fb_config, visual_infos)))
                 } else if let Some(ref egl) = display.egl {
-                    Context::Egl(try!(EglContext::new(egl.clone(), &builder, Some(display.display as *const _), window as *const _)))
+                    Context::Egl(try!(EglContext::new(egl.clone(), &builder, Some(display.display as *const _)).and_then(|p| p.finish(window as *const _))))
                 } else {
                     return Err(CreationError::NotSupported);
                 }
             },
             GlRequest::Specific(Api::OpenGlEs, _) => {
                 if let Some(ref egl) = display.egl {
-                    Context::Egl(try!(EglContext::new(egl.clone(), &builder, Some(display.display as *const _), window as *const _)))
+                    Context::Egl(try!(EglContext::new(egl.clone(), &builder, Some(display.display as *const _)).and_then(|p| p.finish(window as *const _))))
                 } else {
                     return Err(CreationError::NotSupported);
                 }


### PR DESCRIPTION
In order to properly create an X11 window, we need to know the visual ID of the pixel format chosen by EGL. So we split the EGL creation process in two parts.

`EglContext::new` returns a `EglContextPrototype`, which can be used to retreive the native visual ID. This prototype can then be turned into a real context by passing a window.