### PR TITLE
Only listen for mouse events from master devices

### DIFF
--- a/src/api/x11/input.rs
+++ b/src/api/x11/input.rs
@@ -77,7 +77,7 @@ impl XInputEventHandler {
         // X11 events.
         let mut mask: [libc::c_uchar; 2] = [0, 0];
         let mut input_event_mask = ffi::XIEventMask {
-            deviceid: ffi::XIAllDevices,
+            deviceid: ffi::XIAllMasterDevices,
             mask_len: mask.len() as i32,
             mask: mask.as_mut_ptr()
         };


### PR DESCRIPTION
XInput2 has a concept of master and slave devices,
where a slave device is the actual physical device,
attached to a master device representing the cursor or keyboard
focus.

See http://who-t.blogspot.co.uk/2009/05/xi2-recipes-part-1.html

Mouse events were being received from both the master and slave
devices, but we are only interested in events from the master device.

Fixes #533