### PR TITLE
Add aarch64-unknown-linux-gnu support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,9 @@ osmesa-sys = "0.0.5"
 wayland-client = { version = "0.2.0", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
 x11-dl = "~2.0"
+
+[target.aarch64-unknown-linux-gnu.dependencies]
+osmesa-sys = "0.0.5"
+wayland-client = { version = "0.2.0", features = ["egl", "dlopen"] }
+wayland-kbd = "0.2.0"
+x11-dl = "~2.0"

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -22,7 +22,7 @@ pub fn load(window: &glutin::Window) -> Context {
     let gl = gl::Gl::load(window);
 
     let version = unsafe {
-        let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const i8).to_bytes().to_vec();
+        let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const _).to_bytes().to_vec();
         String::from_utf8(data).unwrap()
     };
 

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -492,8 +492,8 @@ impl Window {
         unsafe {
             with_c_str(&*builder.title, |c_name| {
                 let hint = (display.xlib.XAllocClassHint)();
-                (*hint).res_name = c_name as *mut i8;
-                (*hint).res_class = c_name as *mut i8;
+                (*hint).res_name = c_name as *mut libc::c_char;
+                (*hint).res_class = c_name as *mut libc::c_char;
                 (display.xlib.XSetClassHint)(display.display, window, hint);
                 (display.xlib.XFree)(hint as *mut libc::c_void);
             });


### PR DESCRIPTION
* Adding dependencies
* Replacing `i8` with `::libc::c_char` (since `c_char` can be
  unsigned on some platforms, aarch64 is one of them)
* Adding `extern crate libc;` to examples