### PR TITLE
Split `get_inner_size`

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -301,8 +301,23 @@ impl Window {
     ///
     /// Returns `None` if the window no longer exists.
     #[inline]
-    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
+    pub fn get_inner_size_points(&self) -> Option<(u32, u32)> {
         self.window.get_inner_size()
+    }
+
+    /// Returns the size in pixels of the client area of the window.
+    ///
+    /// The client area is the content of the window, excluding the title bar and borders.
+    /// These are the dimensions of the frame buffer, and the dimensions that you should use
+    ///  when you call `glViewport`.
+    ///
+    /// Returns `None` if the window no longer exists.
+    #[inline]
+    pub fn get_inner_size_pixels(&self) -> Option<(u32, u32)> {
+        self.window.get_inner_size().map(|(x, y)| {
+            let hidpi = self.hidpi_factor();
+            ((x as f32 * hidpi) as u32, (y as f32 * hidpi) as u32)
+        })
     }
 
     /// Returns the size in pixels of the window.

--- a/src/window.rs
+++ b/src/window.rs
@@ -300,10 +300,24 @@ impl Window {
     /// To get the dimensions of the frame buffer when calling `glViewport`, multiply with hidpi factor.
     ///
     /// Returns `None` if the window no longer exists.
+    ///
+    /// DEPRECATED
+    #[inline]
+    pub fn get_inner_size(&self) -> Option<(u32, u32)> {
+        self.window.get_inner_size()
+    }
+    
+    /// Returns the size in points of the client area of the window.
+    ///
+    /// The client area is the content of the window, excluding the title bar and borders.
+    /// To get the dimensions of the frame buffer when calling `glViewport`, multiply with hidpi factor.
+    ///
+    /// Returns `None` if the window no longer exists.
     #[inline]
     pub fn get_inner_size_points(&self) -> Option<(u32, u32)> {
         self.window.get_inner_size()
     }
+
 
     /// Returns the size in pixels of the client area of the window.
     ///


### PR DESCRIPTION
Closes https://github.com/tomaka/glutin/issues/542

* Splits `get_inner_size` into `get_inner_size_points` and
`get_inner_size_pixels`