### PR TITLE
Add decorations to wayland windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,24 +75,28 @@ dwmapi-sys = "0.1"
 
 [target.i686-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
-wayland-client = { version = "0.2.0", features = ["egl", "dlopen"] }
+wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
+wayland-window = "0.1.0"
 x11-dl = "~2.0"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
-wayland-client = { version = "0.2.0", features = ["egl", "dlopen"] }
+wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
+wayland-window = "0.1.0"
 x11-dl = "~2.0"
 
 [target.arm-unknown-linux-gnueabihf.dependencies]
 osmesa-sys = "0.0.5"
-wayland-client = { version = "0.2.0", features = ["egl", "dlopen"] }
+wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
+wayland-window = "0.1.0"
 x11-dl = "~2.0"
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
-wayland-client = { version = "0.2.0", features = ["egl", "dlopen"] }
+wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
+wayland-window = "0.1.0"
 x11-dl = "~2.0"

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -257,16 +257,20 @@ impl Window {
             shell_surface.set_fullscreen(ShellFullscreenMethod::Default, Some(&monitor.output));
             ShellWindow::Plain(shell_surface)
         } else {
-            ShellWindow::Decorated(match DecoratedSurface::new(
-                surface,
-                w as i32,
-                h as i32,
-                &wayland_context.registry,
-                Some(&wayland_context.seat)
-            ) {
-                Ok(s) => s,
-                Err(_) => return Err(CreationError::NotSupported)
-            })
+            if builder.decorations {
+                ShellWindow::Decorated(match DecoratedSurface::new(
+                    surface,
+                    w as i32,
+                    h as i32,
+                    &wayland_context.registry,
+                    Some(&wayland_context.seat)
+                ) {
+                    Ok(s) => s,
+                    Err(_) => return Err(CreationError::NotSupported)
+                })
+            } else {
+                ShellWindow::Plain(wayland_context.shell.get_shell_surface(surface))
+            }
         };
 
         let context = {


### PR DESCRIPTION
This improves the wayland backend to properly handle the `.with_decorations()` switch.

It now uses the crate `wayland-window` to draw minimalistic borders that allow resizing and moving the window (but there is not yet a close button).

Currently this leaves the wayland backend as disabled, we need to decide at which point we want to enable it.