### PR TITLE
Minor fixes to wayland backend

### DIFF
--- a/src/api/wayland/context.rs
+++ b/src/api/wayland/context.rs
@@ -218,4 +218,11 @@ impl WaylandContext {
             p.lock().unwrap().remove_handled_surface(sid);
         }
     }
+
+    pub fn push_event_for(&self, sid: SurfaceId, evt: Event) {
+        let mut guard = self.windows_event_queues.lock().unwrap();
+        if let Some(queue) = guard.get(&sid) {
+            queue.lock().unwrap().push_back(evt);
+        }
+    }
 }

--- a/src/api/wayland/context.rs
+++ b/src/api/wayland/context.rs
@@ -86,7 +86,7 @@ impl WaylandContext {
                 if let Some(sid) = sid {
                     let map = event_queues.lock().unwrap();
                     if let Some(queue) = map.get(&sid) {
-                        queue.lock().unwrap().push_back(Event::Moved(x as i32,y as i32))
+                        queue.lock().unwrap().push_back(Event::MouseMoved((x as i32,y as i32)))
                     }
                 }
             });

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -134,6 +134,13 @@ impl Window {
             if let Some(f) = self.resize_callback {
                 f(w as u32, h as u32);
             }
+            if let Some(ref ctxt) = *WAYLAND_CONTEXT {
+                let mut window_guard = self.shell_window.lock().unwrap();
+                ctxt.push_event_for(
+                    window_guard.get_shell().get_wsurface().get_id(),
+                    Event::Resized(w as u32, h as u32)
+                );
+            }
         }
         b
     }


### PR DESCRIPTION
- Properly generate `MouseMoved` (and not erroneous `Moved` events as before)
- Generate a `Resized` event when handling a resize