### PR TITLE
Correct event type

### DIFF
--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -186,7 +186,7 @@ impl<'a> Iterator for PollEventsIterator<'a> {
             }
 
             match xev.get_type() {
-                ffi::KeymapNotify => {
+                ffi::MappingNotify => {
                     unsafe { (xlib.XRefreshKeyboardMapping)(mem::transmute(&xev)); }
                 },
 


### PR DESCRIPTION
KeymapNotify should not be handled by calling XRefreshKeyboardMapping.

XRefreshKeyboardMapping expects XMappingEvent.