### PR TITLE
Handle events for Alt-<Key> and F10 presses in windows

### DIFF
--- a/src/api/win32/callback.rs
+++ b/src/api/win32/callback.rs
@@ -102,6 +102,14 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
             0
         },
 
+        // Prevents default windows menu hotkeys playing unwanted
+        // "ding" sounds. Alternatively could check for WM_SYSCOMMAND
+        // with wparam being SC_KEYMENU, but this may prevent some
+        // other unwanted default hotkeys as well.
+        winapi::WM_SYSCHAR => {
+            0
+        }
+
         winapi::WM_MOUSEMOVE => {
             use events::Event::MouseMoved;
 
@@ -126,15 +134,19 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
             0
         },
 
-        winapi::WM_KEYDOWN => {
+        winapi::WM_KEYDOWN | winapi::WM_SYSKEYDOWN => {
             use events::Event::KeyboardInput;
             use events::ElementState::Pressed;
-            let (scancode, vkey) = event::vkeycode_to_element(wparam, lparam);
-            send_event(window, KeyboardInput(Pressed, scancode, vkey));
-            0
+            if msg == winapi::WM_SYSKEYDOWN && wparam as i32 == winapi::VK_F4 {
+                user32::DefWindowProcW(window, msg, wparam, lparam)
+            } else {
+                let (scancode, vkey) = event::vkeycode_to_element(wparam, lparam);
+                send_event(window, KeyboardInput(Pressed, scancode, vkey));
+                0
+            }
         },
 
-        winapi::WM_KEYUP => {
+        winapi::WM_KEYUP | winapi::WM_SYSKEYUP => {
             use events::Event::KeyboardInput;
             use events::ElementState::Released;
             let (scancode, vkey) = event::vkeycode_to_element(wparam, lparam);


### PR DESCRIPTION
This adds support for detecting key presses while Alt is being held on windows (And F10 whether Alt is down or not).

Alt-F4 has an exception to do its default behaviour of closing the window.