### PR TITLE
[cocoa] add resizable mask to decoration-less windows

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -396,7 +396,8 @@ impl Window {
             };
 
             let masks = if screen.is_some() || !builder.decorations {
-                NSBorderlessWindowMask as NSUInteger
+                NSBorderlessWindowMask as NSUInteger |
+                NSResizableWindowMask as NSUInteger
             } else {
                 NSTitledWindowMask as NSUInteger |
                 NSClosableWindowMask as NSUInteger |


### PR DESCRIPTION
This is required to make window resizable and have a shadow.

Without and with the resizable mask:

<img width="207" alt="screen shot 2015-09-17 at 09 04 08" src="https://cloud.githubusercontent.com/assets/373579/9927036/1781e57c-5d1b-11e5-8e24-f1002b6c77f4.png">
