### PR TITLE
Separate the builder attributes into multiple substates

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -112,7 +112,8 @@ impl Window {
             return Err(OsError(format!("Android's native window is null")));
         }
 
-        let context = try!(EglContext::new(egl::ffi::egl::Egl, &builder, egl::NativeDisplay::Android)
+        let context = try!(EglContext::new(egl::ffi::egl::Egl, &builder.pf_reqs, &builder.opengl,
+                                           egl::NativeDisplay::Android)
                                                 .and_then(|p| p.finish(native_window as *const _)));
 
         let (tx, rx) = channel();
@@ -256,7 +257,7 @@ impl HeadlessContext {
     /// See the docs in the crate root file.
     pub fn new(builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
         let context = try!(EglContext::new(egl::ffi::egl::Egl, &builder, egl::NativeDisplay::Android));
-        let context = try!(context.finish_pbuffer());
+        let context = try!(context.finish_pbuffer(builder.window.dimensions.unwrap_or((800, 600))));     // TODO: 
         Ok(HeadlessContext(context))
     }
 }

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -5,14 +5,16 @@ use libc;
 use api::osmesa::{OsMesaContext, OsMesaCreationError};
 
 use Api;
-use BuilderAttribs;
 use ContextError;
 use CreationError;
 use Event;
+use GlAttributes;
 use GlContext;
 use PixelFormat;
+use PixelFormatRequirements;
 use CursorState;
 use MouseCursor;
+use WindowAttributes;
 
 use std::collections::VecDeque;
 use std::path::Path;
@@ -84,8 +86,14 @@ impl<'a> Iterator for WaitEventsIterator<'a> {
 }
 
 impl Window {
-    pub fn new(builder: BuilderAttribs) -> Result<Window, CreationError> {
-        let opengl = match OsMesaContext::new(builder) {
+    pub fn new(window: &WindowAttributes, pf_reqs: &PixelFormatRequirements,
+               opengl: &GlAttributes<&Window>) -> Result<Window, CreationError>
+    {
+        let opengl = opengl.clone().map_sharing(|w| &w.opengl);
+
+        let opengl = match OsMesaContext::new(window.dimensions.unwrap_or((800, 600)), pf_reqs,
+                                              &opengl)
+        {
             Err(OsMesaCreationError::NotSupported) => return Err(CreationError::NotSupported),
             Err(OsMesaCreationError::CreationError(e)) => return Err(e),
             Ok(c) => c

--- a/src/api/cocoa/headless.rs
+++ b/src/api/cocoa/headless.rs
@@ -1,8 +1,9 @@
 use ContextError;
 use CreationError;
 use CreationError::OsError;
-use BuilderAttribs;
+use GlAttributes;
 use GlContext;
+use PixelFormatRequirements;
 use libc;
 use std::ptr;
 
@@ -27,8 +28,9 @@ pub struct HeadlessContext {
 }
 
 impl HeadlessContext {
-    pub fn new(builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
-        let (width, height) = builder.window.dimensions.unwrap_or((1024, 768));
+    pub fn new((width, height): (u32, u32), pf_reqs: &PixelFormatRequirements,
+               opengl: &GlAttributes<&HeadlessContext>) -> Result<HeadlessContext, CreationError>
+    {
         let context = unsafe {
             let attributes = [
                 NSOpenGLPFAAccelerated as u32,

--- a/src/api/cocoa/headless.rs
+++ b/src/api/cocoa/headless.rs
@@ -28,7 +28,7 @@ pub struct HeadlessContext {
 
 impl HeadlessContext {
     pub fn new(builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
-        let (width, height) = builder.dimensions.unwrap_or((1024, 768));
+        let (width, height) = builder.window.dimensions.unwrap_or((1024, 768));
         let context = unsafe {
             let attributes = [
                 NSOpenGLPFAAccelerated as u32,

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -301,7 +301,7 @@ impl Window {
         };
 
         unsafe {
-            if builder.transparent {
+            if builder.window.transparent {
                 let clear_col = {
                     let cls = Class::get("NSColor").unwrap();
 
@@ -317,7 +317,7 @@ impl Window {
             }
             
             app.activateIgnoringOtherApps_(YES);
-            if builder.visible {
+            if builder.window.visible {
                 window.makeKeyAndOrderFront_(nil);
             } else {
                 window.makeKeyWindow();
@@ -358,7 +358,7 @@ impl Window {
 
     fn create_window(builder: &BuilderAttribs) -> Option<IdRef> {
         unsafe { 
-            let screen = match builder.monitor {
+            let screen = match builder.window.monitor {
                 Some(ref monitor_id) => {
                     let native_id = match monitor_id.get_native_identifier() {
                         NativeMonitorId::Numeric(num) => num,
@@ -390,12 +390,12 @@ impl Window {
             let frame = match screen {
                 Some(screen) => NSScreen::frame(screen),
                 None => {
-                    let (width, height) = builder.dimensions.unwrap_or((800, 600));
+                    let (width, height) = builder.window.dimensions.unwrap_or((800, 600));
                     NSRect::new(NSPoint::new(0., 0.), NSSize::new(width as f64, height as f64))
                 }
             };
 
-            let masks = if screen.is_some() || !builder.decorations {
+            let masks = if screen.is_some() || !builder.window.decorations {
                 NSBorderlessWindowMask as NSUInteger |
                 NSResizableWindowMask as NSUInteger
             } else {
@@ -412,7 +412,7 @@ impl Window {
                 NO,
             ));
             window.non_nil().map(|window| {
-                let title = IdRef::new(NSString::alloc(nil).init_str(&builder.title));
+                let title = IdRef::new(NSString::alloc(nil).init_str(&builder.window.title));
                 window.setTitle_(*title);
                 window.setAcceptsMouseMovedEvents_(YES);
                 if screen.is_some() {

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -267,11 +267,11 @@ impl<'a> Iterator for WaitEventsIterator<'a> {
 impl Window {
     #[cfg(feature = "window")]
     pub fn new(builder: BuilderAttribs) -> Result<Window, CreationError> {
-        if builder.sharing.is_some() {
+        if builder.opengl.sharing.is_some() {
             unimplemented!()
         }
 
-        match builder.gl_robustness {
+        match builder.opengl.robustness {
             Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                 return Err(CreationError::RobustnessNotSupported);
             },
@@ -438,7 +438,7 @@ impl Window {
     }
 
     fn create_context(view: id, builder: &BuilderAttribs) -> Result<(IdRef, PixelFormat), CreationError> {
-        let profile = match (builder.gl_version, builder.gl_version.to_gl_version(), builder.gl_profile) {
+        let profile = match (builder.opengl.version, builder.opengl.version.to_gl_version(), builder.opengl.profile) {
 
             // Note: we are not using ranges because of a rust bug that should be fixed here:
             // https://github.com/rust-lang/rust/pull/27050
@@ -540,7 +540,7 @@ impl Window {
                     };
 
                     cxt.setView_(view);
-                    let value = if builder.vsync { 1 } else { 0 };
+                    let value = if builder.opengl.vsync { 1 } else { 0 };
                     cxt.setValues_forParameter_(&value, NSOpenGLContextParameter::NSOpenGLCPSwapInterval);
 
                     CGLEnable(cxt.CGLContextObj(), kCGLCECrashOnRemovedFunctions);

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -471,16 +471,16 @@ impl Window {
         // full color size and hope for the best. Another hiccup is that
         // `NSOpenGLPFAColorSize` also includes `NSOpenGLPFAAlphaSize`,
         // so we have to account for that as well.
-        let alpha_depth = builder.alpha_bits.unwrap_or(8);
-        let color_depth = builder.color_bits.unwrap_or(24) + alpha_depth;
+        let alpha_depth = builder.pf_reqs.alpha_bits.unwrap_or(8);
+        let color_depth = builder.pf_reqs.color_bits.unwrap_or(24) + alpha_depth;
 
         let mut attributes = vec![
             NSOpenGLPFADoubleBuffer as u32,
             NSOpenGLPFAClosestPolicy as u32,
             NSOpenGLPFAColorSize as u32, color_depth as u32,
             NSOpenGLPFAAlphaSize as u32, alpha_depth as u32,
-            NSOpenGLPFADepthSize as u32, builder.depth_bits.unwrap_or(24) as u32,
-            NSOpenGLPFAStencilSize as u32, builder.stencil_bits.unwrap_or(8) as u32,
+            NSOpenGLPFADepthSize as u32, builder.pf_reqs.depth_bits.unwrap_or(24) as u32,
+            NSOpenGLPFAStencilSize as u32, builder.pf_reqs.stencil_bits.unwrap_or(8) as u32,
             NSOpenGLPFAOpenGLProfile as u32, profile,
         ];
 
@@ -491,7 +491,7 @@ impl Window {
             attributes.push(NSOpenGLPFAColorFloat as u32);
         }
 
-        builder.multisampling.map(|samples| {
+        builder.pf_reqs.multisampling.map(|samples| {
             attributes.push(NSOpenGLPFAMultisample as u32);
             attributes.push(NSOpenGLPFASampleBuffers as u32); attributes.push(1);
             attributes.push(NSOpenGLPFASamples as u32); attributes.push(samples as u32);

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -162,7 +162,7 @@ impl Context {
                    native_display: NativeDisplay)
                    -> Result<ContextPrototype<'a>, CreationError>
     {
-        if builder.sharing.is_some() {
+        if builder.opengl.sharing.is_some() {
             unimplemented!()
         }
 
@@ -197,7 +197,7 @@ impl Context {
 
         // binding the right API and choosing the version
         let (version, api) = unsafe {
-            match builder.gl_version {
+            match builder.opengl.version {
                 GlRequest::Latest => {
                     if egl_version >= (1, 4) {
                         if egl.BindAPI(ffi::egl::OPENGL_API) != 0 {
@@ -394,18 +394,18 @@ impl<'a> ContextPrototype<'a> {
             if let Some(version) = self.version {
                 try!(create_context(&self.egl, self.display, &self.egl_version,
                                     &self.extensions, self.api, version, self.config_id,
-                                    self.builder.gl_debug, self.builder.gl_robustness))
+                                    self.builder.opengl.debug, self.builder.opengl.robustness))
 
             } else if self.api == Api::OpenGlEs {
                 if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                  &self.extensions, self.api, (2, 0), self.config_id,
-                                                 self.builder.gl_debug, self.builder.gl_robustness)
+                                                 self.builder.opengl.debug, self.builder.opengl.robustness)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                         &self.extensions, self.api, (1, 0),
-                                                        self.config_id, self.builder.gl_debug,
-                                                        self.builder.gl_robustness)
+                                                        self.config_id, self.builder.opengl.debug,
+                                                        self.builder.opengl.robustness)
                 {
                     ctxt
                 } else {
@@ -415,19 +415,19 @@ impl<'a> ContextPrototype<'a> {
             } else {
                 if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                  &self.extensions, self.api, (3, 2), self.config_id,
-                                                 self.builder.gl_debug, self.builder.gl_robustness)
+                                                 self.builder.opengl.debug, self.builder.opengl.robustness)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                         &self.extensions, self.api, (3, 1),
-                                                        self.config_id, self.builder.gl_debug,
-                                                        self.builder.gl_robustness)
+                                                        self.config_id, self.builder.opengl.debug,
+                                                        self.builder.opengl.robustness)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                         &self.extensions, self.api, (1, 0),
-                                                        self.config_id, self.builder.gl_debug,
-                                                        self.builder.gl_robustness)
+                                                        self.config_id, self.builder.opengl.debug,
+                                                        self.builder.opengl.robustness)
                 {
                     ctxt
                 } else {

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -2,12 +2,13 @@
            target_os = "dragonfly", target_os = "freebsd"))]
 #![allow(unused_variables)]
 
-use BuilderAttribs;
 use ContextError;
 use CreationError;
+use GlAttributes;
 use GlContext;
 use GlRequest;
 use PixelFormat;
+use PixelFormatRequirements;
 use Robustness;
 use Api;
 
@@ -158,11 +159,11 @@ impl Context {
     /// This function initializes some things and chooses the pixel format.
     ///
     /// To finish the process, you must call `.finish(window)` on the `ContextPrototype`.
-    pub fn new<'a>(egl: ffi::egl::Egl, builder: &'a BuilderAttribs<'a>,
-                   native_display: NativeDisplay)
+    pub fn new<'a>(egl: ffi::egl::Egl, pf_reqs: &PixelFormatRequirements,
+                   opengl: &'a GlAttributes<&'a Context>, native_display: NativeDisplay)
                    -> Result<ContextPrototype<'a>, CreationError>
     {
-        if builder.opengl.sharing.is_some() {
+        if opengl.sharing.is_some() {
             unimplemented!()
         }
 
@@ -197,7 +198,7 @@ impl Context {
 
         // binding the right API and choosing the version
         let (version, api) = unsafe {
-            match builder.opengl.version {
+            match opengl.version {
                 GlRequest::Latest => {
                     if egl_version >= (1, 4) {
                         if egl.BindAPI(ffi::egl::OPENGL_API) != 0 {
@@ -246,10 +247,10 @@ impl Context {
         };
 
         let configs = unsafe { try!(enumerate_configs(&egl, display, &egl_version, api, version)) };
-        let (config_id, pixel_format) = try!(builder.choose_pixel_format(configs.into_iter()));
+        let (config_id, pixel_format) = try!(pf_reqs.choose_pixel_format(configs.into_iter()));
 
         Ok(ContextPrototype {
-            builder: builder,
+            opengl: opengl,
             egl: egl,
             display: display,
             egl_version: egl_version,
@@ -330,7 +331,7 @@ impl Drop for Context {
 }
 
 pub struct ContextPrototype<'a> {
-    builder: &'a BuilderAttribs<'a>,
+    opengl: &'a GlAttributes<&'a Context>,
     egl: ffi::egl::Egl,
     display: ffi::egl::types::EGLDisplay,
     egl_version: (ffi::egl::types::EGLint, ffi::egl::types::EGLint),
@@ -366,9 +367,7 @@ impl<'a> ContextPrototype<'a> {
         self.finish_impl(surface)
     }
 
-    pub fn finish_pbuffer(self) -> Result<Context, CreationError> {
-        let dimensions = self.builder.window.dimensions.unwrap_or((800, 600));
-
+    pub fn finish_pbuffer(self, dimensions: (u32, u32)) -> Result<Context, CreationError> {
         let attrs = &[
             ffi::egl::WIDTH as libc::c_int, dimensions.0 as libc::c_int,
             ffi::egl::HEIGHT as libc::c_int, dimensions.1 as libc::c_int,
@@ -394,18 +393,18 @@ impl<'a> ContextPrototype<'a> {
             if let Some(version) = self.version {
                 try!(create_context(&self.egl, self.display, &self.egl_version,
                                     &self.extensions, self.api, version, self.config_id,
-                                    self.builder.opengl.debug, self.builder.opengl.robustness))
+                                    self.opengl.debug, self.opengl.robustness))
 
             } else if self.api == Api::OpenGlEs {
                 if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                  &self.extensions, self.api, (2, 0), self.config_id,
-                                                 self.builder.opengl.debug, self.builder.opengl.robustness)
+                                                 self.opengl.debug, self.opengl.robustness)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                         &self.extensions, self.api, (1, 0),
-                                                        self.config_id, self.builder.opengl.debug,
-                                                        self.builder.opengl.robustness)
+                                                        self.config_id, self.opengl.debug,
+                                                        self.opengl.robustness)
                 {
                     ctxt
                 } else {
@@ -415,19 +414,19 @@ impl<'a> ContextPrototype<'a> {
             } else {
                 if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                  &self.extensions, self.api, (3, 2), self.config_id,
-                                                 self.builder.opengl.debug, self.builder.opengl.robustness)
+                                                 self.opengl.debug, self.opengl.robustness)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                         &self.extensions, self.api, (3, 1),
-                                                        self.config_id, self.builder.opengl.debug,
-                                                        self.builder.opengl.robustness)
+                                                        self.config_id, self.opengl.debug,
+                                                        self.opengl.robustness)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.egl, self.display, &self.egl_version,
                                                         &self.extensions, self.api, (1, 0),
-                                                        self.config_id, self.builder.opengl.debug,
-                                                        self.builder.opengl.robustness)
+                                                        self.config_id, self.opengl.debug,
+                                                        self.opengl.robustness)
                 {
                     ctxt
                 } else {

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -367,7 +367,7 @@ impl<'a> ContextPrototype<'a> {
     }
 
     pub fn finish_pbuffer(self) -> Result<Context, CreationError> {
-        let dimensions = self.builder.dimensions.unwrap_or((800, 600));
+        let dimensions = self.builder.window.dimensions.unwrap_or((800, 600));
 
         let attrs = &[
             ffi::egl::WIDTH as libc::c_int, dimensions.0 as libc::c_int,

--- a/src/api/emscripten/mod.rs
+++ b/src/api/emscripten/mod.rs
@@ -83,7 +83,7 @@ impl Window {
 
         // setting the attributes
         // FIXME: 
-        /*match builder.gl_version {
+        /*match builder.opengl.version {
             Some((major, minor)) => {
                 attributes.majorVersion = major as libc::c_int;
                 attributes.minorVersion = minor as libc::c_int;

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -1,13 +1,14 @@
 #![cfg(all(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"), feature = "window"))]
 
-use BuilderAttribs;
 use ContextError;
 use CreationError;
+use GlAttributes;
 use GlContext;
 use GlProfile;
 use GlRequest;
 use Api;
 use PixelFormat;
+use PixelFormatRequirements;
 use Robustness;
 
 use libc;
@@ -34,14 +35,14 @@ fn with_c_str<F, T>(s: &str, f: F) -> T where F: FnOnce(*const libc::c_char) -> 
 }
 
 impl Context {
-    pub fn new<'a>(glx: ffi::glx::Glx, xlib: &ffi::Xlib, builder: &'a BuilderAttribs<'a>,
-                   display: *mut ffi::Display)
+    pub fn new<'a>(glx: ffi::glx::Glx, xlib: &ffi::Xlib, pf_reqs: &PixelFormatRequirements,
+                   opengl: &'a GlAttributes<&'a Context>, display: *mut ffi::Display)
                    -> Result<ContextPrototype<'a>, CreationError>
     {
         // finding the pixel format we want
         let (fb_config, pixel_format) = {
             let configs = unsafe { try!(enumerate_configs(&glx, xlib, display)) };
-            try!(builder.choose_pixel_format(configs.into_iter()))
+            try!(pf_reqs.choose_pixel_format(configs.into_iter()))
         };
 
         // getting the visual infos
@@ -57,7 +58,7 @@ impl Context {
 
         Ok(ContextPrototype {
             glx: glx,
-            builder: builder,
+            opengl: opengl,
             display: display,
             fb_config: fb_config,
             visual_infos: unsafe { mem::transmute(visual_infos) },
@@ -120,7 +121,7 @@ impl Drop for Context {
 
 pub struct ContextPrototype<'a> {
     glx: ffi::glx::Glx,
-    builder: &'a BuilderAttribs<'a>,
+    opengl: &'a GlAttributes<&'a Context>,
     display: *mut ffi::Display,
     fb_config: ffi::glx::types::GLXFBConfig,
     visual_infos: ffi::XVisualInfo,
@@ -133,16 +134,9 @@ impl<'a> ContextPrototype<'a> {
     }
 
     pub fn finish(self, window: ffi::Window) -> Result<Context, CreationError> {
-        let share = if let Some(win) = self.builder.opengl.sharing {
-            match win {
-                &PlatformWindow::X(ref win) => match win.x.context {
-                    ::api::x11::Context::Glx(ref c) => c.context,
-                    _ => panic!("Cannot share contexts between different APIs")
-                },
-                _ => panic!("Cannot use glx on a non-X11 window.")
-            }
-        } else {
-            ptr::null()
+        let share = match self.opengl.sharing {
+            Some(ctxt) => ctxt.context,
+            None => ptr::null()
         };
 
         // loading the list of extensions
@@ -160,46 +154,46 @@ impl<'a> ContextPrototype<'a> {
         });
 
         // creating GL context
-        let context = match self.builder.opengl.version {
+        let context = match self.opengl.version {
             GlRequest::Latest => {
                 if let Ok(ctxt) = create_context(&self.glx, &extra_functions, &extensions, (3, 2),
-                                                 self.builder.opengl.profile, self.builder.opengl.debug,
-                                                 self.builder.opengl.robustness, share,
+                                                 self.opengl.profile, self.opengl.debug,
+                                                 self.opengl.robustness, share,
                                                  self.display, self.fb_config, &self.visual_infos)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.glx, &extra_functions, &extensions,
-                                                        (3, 1), self.builder.opengl.profile,
-                                                        self.builder.opengl.debug,
-                                                        self.builder.opengl.robustness, share, self.display,
+                                                        (3, 1), self.opengl.profile,
+                                                        self.opengl.debug,
+                                                        self.opengl.robustness, share, self.display,
                                                         self.fb_config, &self.visual_infos)
                 {
                     ctxt
 
                 } else {
                     try!(create_context(&self.glx, &extra_functions, &extensions, (1, 0),
-                                        self.builder.opengl.profile, self.builder.opengl.debug,
-                                        self.builder.opengl.robustness,
+                                        self.opengl.profile, self.opengl.debug,
+                                        self.opengl.robustness,
                                         share, self.display, self.fb_config, &self.visual_infos))
                 }
             },
             GlRequest::Specific(Api::OpenGl, (major, minor)) => {
                 try!(create_context(&self.glx, &extra_functions, &extensions, (major, minor),
-                                    self.builder.opengl.profile, self.builder.opengl.debug,
-                                    self.builder.opengl.robustness, share, self.display, self.fb_config,
+                                    self.opengl.profile, self.opengl.debug,
+                                    self.opengl.robustness, share, self.display, self.fb_config,
                                     &self.visual_infos))
             },
             GlRequest::Specific(_, _) => panic!("Only OpenGL is supported"),
             GlRequest::GlThenGles { opengl_version: (major, minor), .. } => {
                 try!(create_context(&self.glx, &extra_functions, &extensions, (major, minor),
-                                    self.builder.opengl.profile, self.builder.opengl.debug,
-                                    self.builder.opengl.robustness, share, self.display, self.fb_config,
+                                    self.opengl.profile, self.opengl.debug,
+                                    self.opengl.robustness, share, self.display, self.fb_config,
                                     &self.visual_infos))
             },
         };
 
         // vsync
-        if self.builder.opengl.vsync {
+        if self.opengl.vsync {
             unsafe { self.glx.MakeCurrent(self.display as *mut _, window, context) };
 
             if extra_functions.SwapIntervalEXT.is_loaded() {
@@ -209,7 +203,8 @@ impl<'a> ContextPrototype<'a> {
                 }
 
                 // checking that it worked
-                if self.builder.strict {
+                // TODO: handle this
+                /*if self.builder.strict {
                     let mut swap = unsafe { mem::uninitialized() };
                     unsafe {
                         self.glx.QueryDrawable(self.display as *mut _, window,
@@ -221,7 +216,7 @@ impl<'a> ContextPrototype<'a> {
                         return Err(CreationError::OsError(format!("Couldn't setup vsync: expected \
                                                     interval `1` but got `{}`", swap)));
                     }
-                }
+                }*/
 
             // GLX_MESA_swap_control is not official
             /*} else if extra_functions.SwapIntervalMESA.is_loaded() {
@@ -234,9 +229,10 @@ impl<'a> ContextPrototype<'a> {
                     extra_functions.SwapIntervalSGI(1);
                 }
 
-            } else if self.builder.strict {
+            }/* else if self.builder.strict {
+                // TODO: handle this
                 return Err(CreationError::OsError(format!("Couldn't find any available vsync extension")));
-            }
+            }*/
 
             unsafe { self.glx.MakeCurrent(self.display as *mut _, 0, ptr::null()) };
         }

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -133,7 +133,7 @@ impl<'a> ContextPrototype<'a> {
     }
 
     pub fn finish(self, window: ffi::Window) -> Result<Context, CreationError> {
-        let share = if let Some(win) = self.builder.sharing {
+        let share = if let Some(win) = self.builder.opengl.sharing {
             match win {
                 &PlatformWindow::X(ref win) => match win.x.context {
                     ::api::x11::Context::Glx(ref c) => c.context,
@@ -160,46 +160,46 @@ impl<'a> ContextPrototype<'a> {
         });
 
         // creating GL context
-        let context = match self.builder.gl_version {
+        let context = match self.builder.opengl.version {
             GlRequest::Latest => {
                 if let Ok(ctxt) = create_context(&self.glx, &extra_functions, &extensions, (3, 2),
-                                                 self.builder.gl_profile, self.builder.gl_debug,
-                                                 self.builder.gl_robustness, share,
+                                                 self.builder.opengl.profile, self.builder.opengl.debug,
+                                                 self.builder.opengl.robustness, share,
                                                  self.display, self.fb_config, &self.visual_infos)
                 {
                     ctxt
                 } else if let Ok(ctxt) = create_context(&self.glx, &extra_functions, &extensions,
-                                                        (3, 1), self.builder.gl_profile,
-                                                        self.builder.gl_debug,
-                                                        self.builder.gl_robustness, share, self.display,
+                                                        (3, 1), self.builder.opengl.profile,
+                                                        self.builder.opengl.debug,
+                                                        self.builder.opengl.robustness, share, self.display,
                                                         self.fb_config, &self.visual_infos)
                 {
                     ctxt
 
                 } else {
                     try!(create_context(&self.glx, &extra_functions, &extensions, (1, 0),
-                                        self.builder.gl_profile, self.builder.gl_debug,
-                                        self.builder.gl_robustness,
+                                        self.builder.opengl.profile, self.builder.opengl.debug,
+                                        self.builder.opengl.robustness,
                                         share, self.display, self.fb_config, &self.visual_infos))
                 }
             },
             GlRequest::Specific(Api::OpenGl, (major, minor)) => {
                 try!(create_context(&self.glx, &extra_functions, &extensions, (major, minor),
-                                    self.builder.gl_profile, self.builder.gl_debug,
-                                    self.builder.gl_robustness, share, self.display, self.fb_config,
+                                    self.builder.opengl.profile, self.builder.opengl.debug,
+                                    self.builder.opengl.robustness, share, self.display, self.fb_config,
                                     &self.visual_infos))
             },
             GlRequest::Specific(_, _) => panic!("Only OpenGL is supported"),
             GlRequest::GlThenGles { opengl_version: (major, minor), .. } => {
                 try!(create_context(&self.glx, &extra_functions, &extensions, (major, minor),
-                                    self.builder.gl_profile, self.builder.gl_debug,
-                                    self.builder.gl_robustness, share, self.display, self.fb_config,
+                                    self.builder.opengl.profile, self.builder.opengl.debug,
+                                    self.builder.opengl.robustness, share, self.display, self.fb_config,
                                     &self.visual_infos))
             },
         };
 
         // vsync
-        if self.builder.vsync {
+        if self.builder.opengl.vsync {
             unsafe { self.glx.MakeCurrent(self.display as *mut _, window, context) };
 
             if extra_functions.SwapIntervalEXT.is_loaded() {

--- a/src/api/ios/mod.rs
+++ b/src/api/ios/mod.rs
@@ -219,7 +219,7 @@ impl Window {
 
         let state = &mut *self.delegate_state;
 
-        if builder.multitouch {
+        if builder.window.multitouch {
             let _: () = msg_send![state.view, setMultipleTouchEnabled:YES];
         }
 

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -37,7 +37,7 @@ impl OsMesaContext {
             return Err(OsMesaCreationError::NotSupported);
         }
 
-        let dimensions = builder.dimensions.unwrap();
+        let dimensions = builder.window.dimensions.unwrap();
 
         match builder.opengl.robustness {
             Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -39,7 +39,7 @@ impl OsMesaContext {
 
         let dimensions = builder.dimensions.unwrap();
 
-        match builder.gl_robustness {
+        match builder.opengl.robustness {
             Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                 return Err(CreationError::RobustnessNotSupported.into());
             },

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -3,11 +3,12 @@
 extern crate osmesa_sys;
 
 use Api;
-use BuilderAttribs;
 use ContextError;
 use CreationError;
+use GlAttributes;
 use GlContext;
 use PixelFormat;
+use PixelFormatRequirements;
 use Robustness;
 use libc;
 use std::{mem, ptr};
@@ -32,20 +33,23 @@ impl From<CreationError> for OsMesaCreationError {
 }
 
 impl OsMesaContext {
-    pub fn new(builder: BuilderAttribs) -> Result<OsMesaContext, OsMesaCreationError> {
+    pub fn new(dimensions: (u32, u32), pf_reqs: &PixelFormatRequirements,
+               opengl: &GlAttributes<&OsMesaContext>) -> Result<OsMesaContext, OsMesaCreationError>
+    {
         if let Err(_) = osmesa_sys::OsMesa::try_loading() {
             return Err(OsMesaCreationError::NotSupported);
         }
 
-        let dimensions = builder.window.dimensions.unwrap();
+        if opengl.sharing.is_some() { unimplemented!() }        // TODO: proper error
 
-        match builder.opengl.robustness {
+        match opengl.robustness {
             Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                 return Err(CreationError::RobustnessNotSupported.into());
             },
             _ => ()
         }
 
+        // TODO: use `pf_reqs` for the format
         // TODO: check OpenGL version and return `OpenGlVersionNotSupported` if necessary
 
         Ok(OsMesaContext {

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -291,7 +291,7 @@ impl Window {
             });
             try!(EglContext::new(
                 egl,
-                &builder,
+                &builder.pf_reqs, &builder.opengl.clone().map_sharing(|_| unimplemented!()),        // TODO: 
                 egl::NativeDisplay::Wayland(Some(wayland_context.display.ptr() as *const _)))
                 .and_then(|p| p.finish((**shell_window.get_shell()).ptr() as *const _))
             )

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -251,7 +251,7 @@ impl Window {
 
         if !is_egl_available() { return Err(CreationError::NotSupported) }
 
-        let (w, h) = builder.dimensions.unwrap_or((800, 600));
+        let (w, h) = builder.window.dimensions.unwrap_or((800, 600));
 
         let surface = EGLSurface::new(
             wayland_context.compositor.create_surface(),
@@ -259,12 +259,12 @@ impl Window {
             h as i32
         );
 
-        let mut shell_window = if let Some(PlatformMonitorID::Wayland(ref monitor)) = builder.monitor {
+        let mut shell_window = if let Some(PlatformMonitorID::Wayland(ref monitor)) = builder.window.monitor {
             let shell_surface = wayland_context.shell.get_shell_surface(surface);
             shell_surface.set_fullscreen(ShellFullscreenMethod::Default, Some(&monitor.output));
             ShellWindow::Plain(shell_surface)
         } else {
-            if builder.decorations {
+            if builder.window.decorations {
                 ShellWindow::Decorated(match DecoratedSurface::new(
                     surface,
                     w as i32,

--- a/src/api/wgl/mod.rs
+++ b/src/api/wgl/mod.rs
@@ -131,7 +131,7 @@ impl Context {
         let gl_library = try!(load_opengl32_dll());
 
         // handling vsync
-        if builder.vsync {
+        if builder.opengl.vsync {
             if extensions.split(' ').find(|&i| i == "WGL_EXT_swap_control").is_some() {
                 let _guard = try!(CurrentContextGuard::make_current(hdc, context.0));
 
@@ -220,7 +220,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
         if extensions.split(' ').find(|&i| i == "WGL_ARB_create_context").is_some() {
             let mut attributes = Vec::new();
 
-            match builder.gl_version {
+            match builder.opengl.version {
                 GlRequest::Latest => {},
                 GlRequest::Specific(Api::OpenGl, (major, minor)) => {
                     attributes.push(gl::wgl_extra::CONTEXT_MAJOR_VERSION_ARB as libc::c_int);
@@ -252,7 +252,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
                 },
             }
 
-            if let Some(profile) = builder.gl_profile {
+            if let Some(profile) = builder.opengl.profile {
                 if extensions.split(' ').find(|&i| i == "WGL_ARB_create_context_profile").is_some()
                 {
                     let flag = match profile {
@@ -273,7 +273,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
 
                 // robustness
                 if extensions.split(' ').find(|&i| i == "WGL_ARB_create_context_robustness").is_some() {
-                    match builder.gl_robustness {
+                    match builder.opengl.robustness {
                         Robustness::RobustNoResetNotification | Robustness::TryRobustNoResetNotification => {
                             attributes.push(gl::wgl_extra::CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB as libc::c_int);
                             attributes.push(gl::wgl_extra::NO_RESET_NOTIFICATION_ARB as libc::c_int);
@@ -288,7 +288,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
                         Robustness::NoError => (),
                     }
                 } else {
-                    match builder.gl_robustness {
+                    match builder.opengl.robustness {
                         Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                             return Err(CreationError::RobustnessNotSupported);
                         },
@@ -296,7 +296,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
                     }
                 }
 
-                if builder.gl_debug {
+                if builder.opengl.debug {
                     flags = flags | gl::wgl_extra::CONTEXT_DEBUG_BIT_ARB as libc::c_int;
                 }
 

--- a/src/api/wgl/mod.rs
+++ b/src/api/wgl/mod.rs
@@ -1,12 +1,13 @@
 #![cfg(any(target_os = "windows"))]
 
-use BuilderAttribs;
 use ContextError;
 use CreationError;
+use GlAttributes;
 use GlContext;
 use GlRequest;
 use GlProfile;
 use PixelFormat;
+use PixelFormatRequirements;
 use Robustness;
 use Api;
 
@@ -74,9 +75,8 @@ impl Context {
     /// # Unsafety
     ///
     /// The `window` must continue to exist as long as the resulting `Context` exists.
-    pub unsafe fn new(builder: &BuilderAttribs<'static>, window: winapi::HWND,
-                      builder_sharelists: Option<winapi::HGLRC>)
-                      -> Result<Context, CreationError>
+    pub unsafe fn new(pf_reqs: &PixelFormatRequirements, opengl: &GlAttributes<winapi::HGLRC>,
+                      window: winapi::HWND) -> Result<Context, CreationError>
     {
         let hdc = user32::GetDC(window);
         if hdc.is_null() {
@@ -118,20 +118,20 @@ impl Context {
                 enumerate_native_pixel_formats(hdc)
             };
 
-            let (id, f) = try!(builder.choose_pixel_format(formats));
+            let (id, f) = try!(pf_reqs.choose_pixel_format(formats));
             try!(set_pixel_format(hdc, id));
             f
         };
 
         // creating the OpenGL context
-        let context = try!(create_context(Some((&extra_functions, builder, &extensions)),
-                                          window, hdc, builder_sharelists));
+        let context = try!(create_context(Some((&extra_functions, pf_reqs, opengl, &extensions)),
+                                          window, hdc));
 
         // loading the opengl32 module
         let gl_library = try!(load_opengl32_dll());
 
         // handling vsync
-        if builder.opengl.vsync {
+        if opengl.vsync {
             if extensions.split(' ').find(|&i| i == "WGL_EXT_swap_control").is_some() {
                 let _guard = try!(CurrentContextGuard::make_current(hdc, context.0));
 
@@ -210,17 +210,20 @@ unsafe impl Sync for Context {}
 ///
 /// Otherwise, only the basic API will be used and the chances of `CreationError::NotSupported`
 /// being returned increase.
-unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'static>, &str)>,
-                         _: winapi::HWND, hdc: winapi::HDC, share: Option<winapi::HGLRC>)
+unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &PixelFormatRequirements,
+                                        &GlAttributes<winapi::HGLRC>, &str)>,
+                         _: winapi::HWND, hdc: winapi::HDC)
                          -> Result<ContextWrapper, CreationError>
 {
-    let share = share.unwrap_or(ptr::null_mut());
+    let share;
 
-    if let Some((extra_functions, builder, extensions)) = extra {
+    if let Some((extra_functions, pf_reqs, opengl, extensions)) = extra {
+        share = opengl.sharing.unwrap_or(ptr::null_mut());
+
         if extensions.split(' ').find(|&i| i == "WGL_ARB_create_context").is_some() {
             let mut attributes = Vec::new();
 
-            match builder.opengl.version {
+            match opengl.version {
                 GlRequest::Latest => {},
                 GlRequest::Specific(Api::OpenGl, (major, minor)) => {
                     attributes.push(gl::wgl_extra::CONTEXT_MAJOR_VERSION_ARB as libc::c_int);
@@ -252,7 +255,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
                 },
             }
 
-            if let Some(profile) = builder.opengl.profile {
+            if let Some(profile) = opengl.profile {
                 if extensions.split(' ').find(|&i| i == "WGL_ARB_create_context_profile").is_some()
                 {
                     let flag = match profile {
@@ -273,7 +276,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
 
                 // robustness
                 if extensions.split(' ').find(|&i| i == "WGL_ARB_create_context_robustness").is_some() {
-                    match builder.opengl.robustness {
+                    match opengl.robustness {
                         Robustness::RobustNoResetNotification | Robustness::TryRobustNoResetNotification => {
                             attributes.push(gl::wgl_extra::CONTEXT_RESET_NOTIFICATION_STRATEGY_ARB as libc::c_int);
                             attributes.push(gl::wgl_extra::NO_RESET_NOTIFICATION_ARB as libc::c_int);
@@ -288,7 +291,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
                         Robustness::NoError => (),
                     }
                 } else {
-                    match builder.opengl.robustness {
+                    match opengl.robustness {
                         Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                             return Err(CreationError::RobustnessNotSupported);
                         },
@@ -296,7 +299,7 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
                     }
                 }
 
-                if builder.opengl.debug {
+                if opengl.debug {
                     flags = flags | gl::wgl_extra::CONTEXT_DEBUG_BIT_ARB as libc::c_int;
                 }
 
@@ -319,7 +322,10 @@ unsafe fn create_context(extra: Option<(&gl::wgl_extra::Wgl, &BuilderAttribs<'st
                 return Ok(ContextWrapper(ctxt as winapi::HGLRC));
             }
         }
-    };
+
+    } else {
+        share = ptr::null_mut();
+    }
 
     let ctxt = gl::wgl::CreateContext(hdc as *const libc::c_void);
     if ctxt.is_null() {
@@ -544,7 +550,7 @@ unsafe fn load_extra_functions(window: winapi::HWND) -> Result<gl::wgl_extra::Wg
     }
 
     // creating the dummy OpenGL context and making it current
-    let dummy_context = try!(create_context(None, dummy_window.0, dummy_window.1, None));
+    let dummy_context = try!(create_context(None, dummy_window.0, dummy_window.1));
     let _current_context = try!(CurrentContextGuard::make_current(dummy_window.1,
                                                                   dummy_context.0));
 

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -11,7 +11,6 @@ use super::WindowWrapper;
 use super::Context;
 
 use Api;
-use BuilderAttribs;
 use CreationError;
 use CreationError::OsError;
 use CursorState;

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -159,7 +159,7 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
     };
 
     // creating the OpenGL context
-    let context = match builder.gl_version {
+    let context = match builder.opengl.version {
         GlRequest::Specific(Api::OpenGlEs, (_major, _minor)) => {
             if let Some(egl) = egl {
                 if let Ok(c) = EglContext::new(egl, &builder,

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -162,7 +162,7 @@ unsafe fn init(title: Vec<u16>, builder: BuilderAttribs<'static>,
     let context = match builder.opengl.version {
         GlRequest::Specific(Api::OpenGlEs, (_major, _minor)) => {
             if let Some(egl) = egl {
-                if let Ok(c) = EglContext::new(egl, &builder,
+                if let Ok(c) = EglContext::new(egl, &builder.pf_reqs, &builder.opengl.clone().map_sharing(|_| unimplemented!()),
                                                egl::NativeDisplay::Other(Some(ptr::null())))
                                                              .and_then(|p| p.finish(real_window.0))
                 {

--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -13,11 +13,14 @@ use libc;
 use ContextError;
 use {CreationError, Event, MouseCursor};
 use CursorState;
+use GlAttributes;
 use GlContext;
 
 use Api;
 use PixelFormat;
+use PixelFormatRequirements;
 use BuilderAttribs;
+use WindowAttributes;
 
 pub use self::monitor::{MonitorID, get_available_monitors, get_primary_monitor};
 
@@ -83,15 +86,18 @@ impl WindowProxy {
 
 impl Window {
     /// See the docs in the crate root file.
-    pub fn new(builder: BuilderAttribs, egl: Option<&Egl>) -> Result<Window, CreationError> {
-        let opengl = builder.opengl.clone().map_sharing(|sharing| {
+    pub fn new(window: &WindowAttributes, pf_reqs: &PixelFormatRequirements,
+               opengl: &GlAttributes<&Window>, egl: Option<&Egl>)
+               -> Result<Window, CreationError>
+    {
+        let opengl = opengl.clone().map_sharing(|sharing| {
             match sharing.context {
                 Context::Wgl(ref c) => RawContext::Wgl(c.get_hglrc()),
                 Context::Egl(_) => unimplemented!(),        // FIXME: 
             }
         });
 
-        init::new_window(&builder.window, &builder.pf_reqs, &opengl, egl)
+        init::new_window(window, pf_reqs, &opengl, egl)
     }
 
     /// See the docs in the crate root file.

--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -84,14 +84,14 @@ impl WindowProxy {
 impl Window {
     /// See the docs in the crate root file.
     pub fn new(builder: BuilderAttribs, egl: Option<&Egl>) -> Result<Window, CreationError> {
-        let (builder, sharing) = builder.extract_non_static();
-
-        let sharing = sharing.map(|w| match w.context {
-            Context::Wgl(ref c) => RawContext::Wgl(c.get_hglrc()),
-            Context::Egl(_) => unimplemented!(),        // FIXME: 
+        let opengl = builder.opengl.clone().map_sharing(|sharing| {
+            match sharing.context {
+                Context::Wgl(ref c) => RawContext::Wgl(c.get_hglrc()),
+                Context::Egl(_) => unimplemented!(),        // FIXME: 
+            }
         });
 
-        init::new_window(builder, sharing, egl)
+        init::new_window(&builder.window, &builder.pf_reqs, &opengl, egl)
     }
 
     /// See the docs in the crate root file.

--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -19,7 +19,6 @@ use GlContext;
 use Api;
 use PixelFormat;
 use PixelFormatRequirements;
-use BuilderAttribs;
 use WindowAttributes;
 
 pub use self::monitor::{MonitorID, get_available_monitors, get_primary_monitor};

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -349,22 +349,23 @@ impl Window {
             Egl(::api::egl::ContextPrototype<'a>),
         }
         let builder_clone = builder.clone();
-        let builder_clone_opengl = builder_clone.opengl.clone().map_sharing(|_| unimplemented!());
+        let builder_clone_opengl_glx = builder_clone.opengl.clone().map_sharing(|_| unimplemented!());      // FIXME: 
+        let builder_clone_opengl_egl = builder_clone.opengl.clone().map_sharing(|_| unimplemented!());      // FIXME: 
         let context = match builder.opengl.version {
             GlRequest::Latest | GlRequest::Specific(Api::OpenGl, _) | GlRequest::GlThenGles { .. } => {
                 // GLX should be preferred over EGL, otherwise crashes may occur
                 // on X11 – issue #314
                 if let Some(ref glx) = display.glx {
-                    Prototype::Glx(try!(GlxContext::new(glx.clone(), &display.xlib, &builder_clone, display.display)))
+                    Prototype::Glx(try!(GlxContext::new(glx.clone(), &display.xlib, &builder_clone.pf_reqs, &builder_clone_opengl_glx, display.display)))
                 } else if let Some(ref egl) = display.egl {
-                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone.pf_reqs, &builder_clone_opengl, egl::NativeDisplay::X11(Some(display.display as *const _)))))
+                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone.pf_reqs, &builder_clone_opengl_egl, egl::NativeDisplay::X11(Some(display.display as *const _)))))
                 } else {
                     return Err(CreationError::NotSupported);
                 }
             },
             GlRequest::Specific(Api::OpenGlEs, _) => {
                 if let Some(ref egl) = display.egl {
-                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone.pf_reqs, &builder_clone_opengl, egl::NativeDisplay::X11(Some(display.display as *const _)))))
+                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone.pf_reqs, &builder_clone_opengl_egl, egl::NativeDisplay::X11(Some(display.display as *const _)))))
                 } else {
                     return Err(CreationError::NotSupported);
                 }

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -349,7 +349,7 @@ impl Window {
             Egl(::api::egl::ContextPrototype<'a>),
         }
         let builder_clone = builder.clone();
-        let context = match builder.gl_version {
+        let context = match builder.opengl.version {
             GlRequest::Latest | GlRequest::Specific(Api::OpenGl, _) | GlRequest::GlThenGles { .. } => {
                 // GLX should be preferred over EGL, otherwise crashes may occur
                 // on X11 – issue #314

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -349,6 +349,7 @@ impl Window {
             Egl(::api::egl::ContextPrototype<'a>),
         }
         let builder_clone = builder.clone();
+        let builder_clone_opengl = builder_clone.opengl.clone().map_sharing(|_| unimplemented!());
         let context = match builder.opengl.version {
             GlRequest::Latest | GlRequest::Specific(Api::OpenGl, _) | GlRequest::GlThenGles { .. } => {
                 // GLX should be preferred over EGL, otherwise crashes may occur
@@ -356,14 +357,14 @@ impl Window {
                 if let Some(ref glx) = display.glx {
                     Prototype::Glx(try!(GlxContext::new(glx.clone(), &display.xlib, &builder_clone, display.display)))
                 } else if let Some(ref egl) = display.egl {
-                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone, egl::NativeDisplay::X11(Some(display.display as *const _)))))
+                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone.pf_reqs, &builder_clone_opengl, egl::NativeDisplay::X11(Some(display.display as *const _)))))
                 } else {
                     return Err(CreationError::NotSupported);
                 }
             },
             GlRequest::Specific(Api::OpenGlEs, _) => {
                 if let Some(ref egl) = display.egl {
-                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone, egl::NativeDisplay::X11(Some(display.display as *const _)))))
+                    Prototype::Egl(try!(EglContext::new(egl.clone(), &builder_clone.pf_reqs, &builder_clone_opengl, egl::NativeDisplay::X11(Some(display.display as *const _)))))
                 } else {
                     return Err(CreationError::NotSupported);
                 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -6,6 +6,7 @@ use GlRequest;
 use GlContext;
 use PixelFormat;
 use Robustness;
+use WindowAttributes;
 
 use gl_common;
 use libc;
@@ -23,7 +24,10 @@ impl HeadlessRendererBuilder {
         HeadlessRendererBuilder {
             attribs: BuilderAttribs {
                 headless: true,
-                dimensions: Some((width, height)),
+                window: WindowAttributes {
+                    dimensions: Some((width, height)),
+                    .. Default::default()
+                },
                 .. BuilderAttribs::new()
             },
         }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -31,7 +31,7 @@ impl HeadlessRendererBuilder {
 
     /// Sets how the backend should choose the OpenGL API and version.
     pub fn with_gl(mut self, request: GlRequest) -> HeadlessRendererBuilder {
-        self.attribs.gl_version = request;
+        self.attribs.opengl.version = request;
         self
     }
 
@@ -40,13 +40,13 @@ impl HeadlessRendererBuilder {
     /// The default value for this flag is `cfg!(ndebug)`, which means that it's enabled
     /// when you run `cargo build` and disabled when you run `cargo build --release`.
     pub fn with_gl_debug_flag(mut self, flag: bool) -> HeadlessRendererBuilder {
-        self.attribs.gl_debug = flag;
+        self.attribs.opengl.debug = flag;
         self
     }
 
     /// Sets the robustness of the OpenGL context. See the docs of `Robustness`.
     pub fn with_gl_robustness(mut self, robustness: Robustness) -> HeadlessRendererBuilder {
-        self.attribs.gl_robustness = robustness;
+        self.attribs.opengl.robustness = robustness;
         self
     }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,10 +1,11 @@
 use Api;
-use BuilderAttribs;
 use ContextError;
 use CreationError;
+use GlAttributes;
 use GlRequest;
 use GlContext;
 use PixelFormat;
+use PixelFormatRequirements;
 use Robustness;
 use WindowAttributes;
 
@@ -14,28 +15,25 @@ use libc;
 use platform;
 
 /// Object that allows you to build headless contexts.
-pub struct HeadlessRendererBuilder {
-    attribs: BuilderAttribs<'static>,
+pub struct HeadlessRendererBuilder<'a> {
+    dimensions: (u32, u32),
+    pf_reqs: PixelFormatRequirements,
+    opengl: GlAttributes<&'a platform::HeadlessContext>,
 }
 
-impl HeadlessRendererBuilder {
+impl<'a> HeadlessRendererBuilder<'a> {
     /// Initializes a new `HeadlessRendererBuilder` with default values.
-    pub fn new(width: u32, height: u32) -> HeadlessRendererBuilder {
+    pub fn new(width: u32, height: u32) -> HeadlessRendererBuilder<'a> {
         HeadlessRendererBuilder {
-            attribs: BuilderAttribs {
-                headless: true,
-                window: WindowAttributes {
-                    dimensions: Some((width, height)),
-                    .. Default::default()
-                },
-                .. BuilderAttribs::new()
-            },
+            dimensions: (width, height),
+            pf_reqs: Default::default(),
+            opengl: Default::default(),
         }
     }
 
     /// Sets how the backend should choose the OpenGL API and version.
-    pub fn with_gl(mut self, request: GlRequest) -> HeadlessRendererBuilder {
-        self.attribs.opengl.version = request;
+    pub fn with_gl(mut self, request: GlRequest) -> HeadlessRendererBuilder<'a> {
+        self.opengl.version = request;
         self
     }
 
@@ -43,14 +41,14 @@ impl HeadlessRendererBuilder {
     ///
     /// The default value for this flag is `cfg!(ndebug)`, which means that it's enabled
     /// when you run `cargo build` and disabled when you run `cargo build --release`.
-    pub fn with_gl_debug_flag(mut self, flag: bool) -> HeadlessRendererBuilder {
-        self.attribs.opengl.debug = flag;
+    pub fn with_gl_debug_flag(mut self, flag: bool) -> HeadlessRendererBuilder<'a> {
+        self.opengl.debug = flag;
         self
     }
 
     /// Sets the robustness of the OpenGL context. See the docs of `Robustness`.
-    pub fn with_gl_robustness(mut self, robustness: Robustness) -> HeadlessRendererBuilder {
-        self.attribs.opengl.robustness = robustness;
+    pub fn with_gl_robustness(mut self, robustness: Robustness) -> HeadlessRendererBuilder<'a> {
+        self.opengl.robustness = robustness;
         self
     }
 
@@ -59,15 +57,15 @@ impl HeadlessRendererBuilder {
     /// Error should be very rare and only occur in case of permission denied, incompatible system,
     ///  out of memory, etc.
     pub fn build(self) -> Result<HeadlessContext, CreationError> {
-        platform::HeadlessContext::new(self.attribs).map(|w| HeadlessContext { context: w })
+        platform::HeadlessContext::new(self.dimensions, &self.pf_reqs, &self.opengl)
+                .map(|w| HeadlessContext { context: w })
     }
 
     /// Builds the headless context.
     ///
     /// The context is build in a *strict* way. That means that if the backend couldn't give
     /// you what you requested, an `Err` will be returned.
-    pub fn build_strict(mut self) -> Result<HeadlessContext, CreationError> {
-        self.attribs.strict = true;
+    pub fn build_strict(self) -> Result<HeadlessContext, CreationError> {
         self.build()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,10 +371,6 @@ pub struct BuilderAttribs<'a> {
     #[allow(dead_code)]
     headless: bool,
     strict: bool,
-    dimensions: Option<(u32, u32)>,
-    title: String,
-    monitor: Option<platform::MonitorID>,
-    visible: bool,
     multisampling: Option<u16>,
     depth_bits: Option<u8>,
     stencil_bits: Option<u8>,
@@ -382,9 +378,7 @@ pub struct BuilderAttribs<'a> {
     alpha_bits: Option<u8>,
     stereoscopy: bool,
     srgb: Option<bool>,
-    transparent: bool,
-    decorations: bool,
-    multitouch: bool,
+    window: WindowAttributes,
     opengl: GlAttributes<&'a platform::Window>,
 }
 
@@ -393,10 +387,6 @@ impl BuilderAttribs<'static> {
         BuilderAttribs {
             headless: false,
             strict: false,
-            dimensions: None,
-            title: "glutin window".to_string(),
-            monitor: None,
-            visible: true,
             multisampling: None,
             depth_bits: None,
             stencil_bits: None,
@@ -404,9 +394,7 @@ impl BuilderAttribs<'static> {
             alpha_bits: None,
             stereoscopy: false,
             srgb: None,
-            transparent: false,
-            decorations: true,
-            multitouch: false,
+            window: Default::default(),
             opengl: Default::default(),
         }
     }
@@ -420,10 +408,6 @@ impl<'a> BuilderAttribs<'a> {
         let new_attribs = BuilderAttribs {
             headless: self.headless,
             strict: self.strict,
-            dimensions: self.dimensions,
-            title: self.title,
-            monitor: self.monitor,
-            visible: self.visible,
             multisampling: self.multisampling,
             depth_bits: self.depth_bits,
             stencil_bits: self.stencil_bits,
@@ -431,9 +415,7 @@ impl<'a> BuilderAttribs<'a> {
             alpha_bits: self.alpha_bits,
             stereoscopy: self.stereoscopy,
             srgb: self.srgb,
-            transparent: self.transparent,
-            decorations: self.decorations,
-            multitouch: self.multitouch,
+            window: self.window,
             opengl: GlAttributes {
                 sharing: None,
                 version: self.opengl.version,
@@ -544,6 +526,59 @@ impl<'a> BuilderAttribs<'a> {
         });
 
         formats.into_iter().next().ok_or(CreationError::NoAvailablePixelFormat)
+    }
+}
+
+/// Attributes to use when creating a window.
+#[derive(Clone)]
+pub struct WindowAttributes {
+    /// The dimensions of the window. If this is `None`, some platform-specific dimensions will be
+    /// used.
+    ///
+    /// The default is `None`.
+    pub dimensions: Option<(u32, u32)>,
+
+    /// If `Some`, the window will be in fullscreen mode with the given monitor.
+    ///
+    /// The default is `None`.
+    pub monitor: Option<platform::MonitorID>,
+
+    /// The title of the window in the title bar.
+    ///
+    /// The default is `"glutin window"`.
+    pub title: String,
+
+    /// Whether the window should be immediately visible upon creation.
+    ///
+    /// The default is `true`.
+    pub visible: bool,
+
+    /// Whether the the window should be transparent. If this is true, writing colors
+    /// with alpha values different than `1.0` will produce a transparent window.
+    ///
+    /// The default is `false`.
+    pub transparent: bool,
+
+    /// Whether the window should have borders and bars.
+    ///
+    /// The default is `true`.
+    pub decorations: bool,
+
+    /// ??? TODO: document me
+    pub multitouch: bool,
+}
+
+impl Default for WindowAttributes {
+    fn default() -> WindowAttributes {
+        WindowAttributes {
+            dimensions: None,
+            monitor: None,
+            title: "glutin window".to_owned(),
+            visible: true,
+            transparent: false,
+            decorations: true,
+            multitouch: false,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,28 +389,6 @@ impl BuilderAttribs<'static> {
 }
 
 impl<'a> BuilderAttribs<'a> {
-    #[allow(dead_code)]
-    fn extract_non_static(mut self) -> (BuilderAttribs<'static>, Option<&'a platform::Window>) {
-        let sharing = self.opengl.sharing.take();
-
-        let new_attribs = BuilderAttribs {
-            headless: self.headless,
-            strict: self.strict,
-            pf_reqs: self.pf_reqs,
-            window: self.window,
-            opengl: GlAttributes {
-                sharing: None,
-                version: self.opengl.version,
-                profile: self.opengl.profile,
-                debug: self.opengl.debug,
-                robustness: self.opengl.robustness,
-                vsync: self.opengl.vsync,
-            },
-        };
-
-        (new_attribs, sharing)
-    }
-
     fn choose_pixel_format<T, I>(&self, iter: I) -> Result<(T, PixelFormat), CreationError>
                                  where I: IntoIterator<Item=(T, PixelFormat)>, T: Clone
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,6 +629,20 @@ pub struct GlAttributes<S> {
     pub vsync: bool,
 }
 
+impl<S> GlAttributes<S> {
+    /// Turns the `sharing` parameter into another type by calling a closure.
+    pub fn map_sharing<F, T>(self, f: F) -> GlAttributes<T> where F: FnOnce(S) -> T {
+        GlAttributes {
+            sharing: self.sharing.map(f),
+            version: self.version,
+            profile: self.profile,
+            debug: self.debug,
+            robustness: self.robustness,
+            vsync: self.vsync,
+        }
+    }
+}
+
 impl<S> Default for GlAttributes<S> {
     fn default() -> GlAttributes<S> {
         GlAttributes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,40 +362,7 @@ pub struct PixelFormat {
     pub multisampling: Option<u16>,
     pub srgb: bool,
 }
-
-/// Attributes
-// FIXME: remove `pub` (https://github.com/rust-lang/rust/issues/23585)
-#[derive(Clone)]
-#[doc(hidden)]
-pub struct BuilderAttribs<'a> {
-    #[allow(dead_code)]
-    headless: bool,
-    strict: bool,
-    pf_reqs: PixelFormatRequirements,
-    window: WindowAttributes,
-    opengl: GlAttributes<&'a platform::Window>,
-}
-
-impl BuilderAttribs<'static> {
-    fn new() -> BuilderAttribs<'static> {
-        BuilderAttribs {
-            headless: false,
-            strict: false,
-            pf_reqs: Default::default(),
-            window: Default::default(),
-            opengl: Default::default(),
-        }
-    }
-}
-
-impl<'a> BuilderAttribs<'a> {
-    fn choose_pixel_format<T, I>(&self, iter: I) -> Result<(T, PixelFormat), CreationError>
-                                 where I: IntoIterator<Item=(T, PixelFormat)>, T: Clone
-    {
-        self.pf_reqs.choose_pixel_format(iter)
-    }
-}
-
+    
 /// VERY UNSTABLE! Describes how the backend should choose a pixel format.
 #[derive(Clone, Debug)]
 #[allow(missing_docs)]

--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -6,14 +6,16 @@ pub use api::x11::{WaitEventsIterator, PollEventsIterator};*/
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-use BuilderAttribs;
 use ContextError;
 use CreationError;
 use CursorState;
 use Event;
+use GlAttributes;
 use GlContext;
 use MouseCursor;
 use PixelFormat;
+use PixelFormatRequirements;
+use WindowAttributes;
 use libc;
 
 use api::wayland;
@@ -161,28 +163,26 @@ impl<'a> Iterator for WaitEventsIterator<'a> {
 }
 
 impl Window {
-    pub fn new(builder: BuilderAttribs) -> Result<Window, CreationError> {
-        let window = builder.window;
-        let pf_reqs = builder.pf_reqs;
-        let opengl = builder.opengl;
-
+    pub fn new(window: &WindowAttributes, pf_reqs: &PixelFormatRequirements,
+               opengl: &GlAttributes<&Window>) -> Result<Window, CreationError>
+    {
         match *BACKEND {
             Backend::Wayland => {
-                let opengl = opengl.map_sharing(|w| match w {
+                let opengl = opengl.clone().map_sharing(|w| match w {
                     &Window::Wayland(ref w) => w,
                     _ => panic!()       // TODO: return an error
                 });
 
-                wayland::Window::new(&window, &pf_reqs, &opengl).map(Window::Wayland)
+                wayland::Window::new(window, pf_reqs, &opengl).map(Window::Wayland)
             },
 
             Backend::X(ref connec) => {
-                let opengl = opengl.map_sharing(|w| match w {
+                let opengl = opengl.clone().map_sharing(|w| match w {
                     &Window::X(ref w) => w,
                     _ => panic!()       // TODO: return an error
                 });
 
-                x11::Window::new(connec, &window, &pf_reqs, &opengl).map(Window::X)
+                x11::Window::new(connec, window, pf_reqs, &opengl).map(Window::X)
             },
 
             Backend::Error(ref error) => Err(CreationError::NoBackendAvailable(Box::new(error.clone())))

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,11 +1,12 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
 
 use Api;
-use BuilderAttribs;
 use ContextError;
 use CreationError;
+use GlAttributes;
 use GlContext;
 use PixelFormat;
+use PixelFormatRequirements;
 use libc;
 
 use api::osmesa::{self, OsMesaContext};
@@ -25,8 +26,12 @@ pub type MonitorID = ();       // TODO: hack to make things work
 pub struct HeadlessContext(OsMesaContext);
 
 impl HeadlessContext {
-    pub fn new(builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
-        match OsMesaContext::new(builder) {
+    pub fn new(dimensions: (u32, u32), pf_reqs: &PixelFormatRequirements,
+               opengl: &GlAttributes<&HeadlessContext>) -> Result<HeadlessContext, CreationError>
+    {
+        let opengl = opengl.clone().map_sharing(|c| &c.0);
+
+        match OsMesaContext::new(dimensions, pf_reqs, &opengl) {
             Ok(c) => return Ok(HeadlessContext(c)),
             Err(osmesa::OsMesaCreationError::NotSupported) => (),
             Err(osmesa::OsMesaCreationError::CreationError(e)) => return Err(e),

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -86,7 +86,7 @@ pub enum HeadlessContext {
 
 impl HeadlessContext {
     pub fn new(mut builder: BuilderAttribs) -> Result<HeadlessContext, CreationError> {
-        builder.visible = false;
+        builder.window.visible = false;
 
         // if EGL is available, we try using EGL first
         // if EGL returns an error, we try the hidden window method

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -58,7 +58,8 @@ pub struct Window(win32::Window);
 impl Window {
     /// See the docs in the crate root file.
     pub fn new(builder: BuilderAttribs) -> Result<Window, CreationError> {
-        win32::Window::new(builder, EGL.as_ref().map(|w| &w.0)).map(|w| Window(w))
+        win32::Window::new(&builder.window, &builder.pf_reqs, &builder.opengl.clone().map_sharing(|w| &w.0),
+                           EGL.as_ref().map(|w| &w.0)).map(|w| Window(w))
     }
 }
 
@@ -101,7 +102,8 @@ impl HeadlessContext {
             }
         }
 
-        let window = try!(win32::Window::new(builder, EGL.as_ref().map(|w| &w.0)));
+        let window = try!(win32::Window::new(&builder.window, &builder.pf_reqs, &builder.opengl.clone().map_sharing(|w| &w.0),
+                                             EGL.as_ref().map(|w| &w.0)));
         Ok(HeadlessContext::HiddenWindow(window))
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -91,8 +91,9 @@ impl HeadlessContext {
         // if EGL is available, we try using EGL first
         // if EGL returns an error, we try the hidden window method
         if let &Some(ref egl) = &*EGL {
-            let context = EglContext::new(egl.0.clone(), &builder, egl::NativeDisplay::Other(None))
-                                .and_then(|prototype| prototype.finish_pbuffer())
+            let context = EglContext::new(egl.0.clone(), &builder.pf_reqs, &builder.opengl.clone().map_sharing(|_| unimplemented!()),       // TODO: 
+                                          egl::NativeDisplay::Other(None))
+                                .and_then(|prototype| prototype.finish_pbuffer(builder.window.dimensions.unwrap_or((800, 600))))         // TODO:
                                 .map(|ctxt| HeadlessContext::EglPbuffer(ctxt));
 
             if let Ok(context) = context {

--- a/src/window.rs
+++ b/src/window.rs
@@ -110,38 +110,38 @@ impl<'a> WindowBuilder<'a> {
     /// Will panic if `samples` is not a power of two.
     pub fn with_multisampling(mut self, samples: u16) -> WindowBuilder<'a> {
         assert!(samples.is_power_of_two());
-        self.attribs.multisampling = Some(samples);
+        self.attribs.pf_reqs.multisampling = Some(samples);
         self
     }
 
     /// Sets the number of bits in the depth buffer.
     pub fn with_depth_buffer(mut self, bits: u8) -> WindowBuilder<'a> {
-        self.attribs.depth_bits = Some(bits);
+        self.attribs.pf_reqs.depth_bits = Some(bits);
         self
     }
 
     /// Sets the number of bits in the stencil buffer.
     pub fn with_stencil_buffer(mut self, bits: u8) -> WindowBuilder<'a> {
-        self.attribs.stencil_bits = Some(bits);
+        self.attribs.pf_reqs.stencil_bits = Some(bits);
         self
     }
 
     /// Sets the number of bits in the color buffer.
     pub fn with_pixel_format(mut self, color_bits: u8, alpha_bits: u8) -> WindowBuilder<'a> {
-        self.attribs.color_bits = Some(color_bits);
-        self.attribs.alpha_bits = Some(alpha_bits);
+        self.attribs.pf_reqs.color_bits = Some(color_bits);
+        self.attribs.pf_reqs.alpha_bits = Some(alpha_bits);
         self
     }
 
     /// Request the backend to be stereoscopic.
     pub fn with_stereoscopy(mut self) -> WindowBuilder<'a> {
-        self.attribs.stereoscopy = true;
+        self.attribs.pf_reqs.stereoscopy = true;
         self
     }
 
     /// Sets whether sRGB should be enabled on the window. `None` means "I don't care".
     pub fn with_srgb(mut self, srgb_enabled: Option<bool>) -> WindowBuilder<'a> {
-        self.attribs.srgb = srgb_enabled;
+        self.attribs.pf_reqs.srgb = srgb_enabled;
         self
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -60,19 +60,19 @@ impl<'a> WindowBuilder<'a> {
     ///
     /// There are some exceptions, like FBOs or VAOs. See the OpenGL documentation.
     pub fn with_shared_lists(mut self, other: &'a Window) -> WindowBuilder<'a> {
-        self.attribs.sharing = Some(&other.window);
+        self.attribs.opengl.sharing = Some(&other.window);
         self
     }
 
     /// Sets how the backend should choose the OpenGL API and version.
     pub fn with_gl(mut self, request: GlRequest) -> WindowBuilder<'a> {
-        self.attribs.gl_version = request;
+        self.attribs.opengl.version = request;
         self
     }
 
     /// Sets the desired OpenGL context profile.
     pub fn with_gl_profile(mut self, profile: GlProfile) -> WindowBuilder<'a> {
-        self.attribs.gl_profile = Some(profile);
+        self.attribs.opengl.profile = Some(profile);
         self
     }
 
@@ -81,19 +81,19 @@ impl<'a> WindowBuilder<'a> {
     /// The default value for this flag is `cfg!(debug_assertions)`, which means that it's enabled
     /// when you run `cargo build` and disabled when you run `cargo build --release`.
     pub fn with_gl_debug_flag(mut self, flag: bool) -> WindowBuilder<'a> {
-        self.attribs.gl_debug = flag;
+        self.attribs.opengl.debug = flag;
         self
     }
 
     /// Sets the robustness of the OpenGL context. See the docs of `Robustness`.
     pub fn with_gl_robustness(mut self, robustness: Robustness) -> WindowBuilder<'a> {
-        self.attribs.gl_robustness = robustness;
+        self.attribs.opengl.robustness = robustness;
         self
     }
 
     /// Requests that the window has vsync enabled.
     pub fn with_vsync(mut self) -> WindowBuilder<'a> {
-        self.attribs.vsync = true;
+        self.attribs.opengl.vsync = true;
         self
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -37,13 +37,13 @@ impl<'a> WindowBuilder<'a> {
     ///
     /// Width and height are in pixels.
     pub fn with_dimensions(mut self, width: u32, height: u32) -> WindowBuilder<'a> {
-        self.attribs.dimensions = Some((width, height));
+        self.attribs.window.dimensions = Some((width, height));
         self
     }
 
     /// Requests a specific title for the window.
     pub fn with_title(mut self, title: String) -> WindowBuilder<'a> {
-        self.attribs.title = title;
+        self.attribs.window.title = title;
         self
     }
 
@@ -52,7 +52,7 @@ impl<'a> WindowBuilder<'a> {
     /// If you don't specify dimensions for the window, it will match the monitor's.
     pub fn with_fullscreen(mut self, monitor: MonitorID) -> WindowBuilder<'a> {
         let MonitorID(monitor) = monitor;
-        self.attribs.monitor = Some(monitor);
+        self.attribs.window.monitor = Some(monitor);
         self
     }
 
@@ -99,7 +99,7 @@ impl<'a> WindowBuilder<'a> {
 
     /// Sets whether the window will be initially hidden or visible.
     pub fn with_visibility(mut self, visible: bool) -> WindowBuilder<'a> {
-        self.attribs.visible = visible;
+        self.attribs.window.visible = visible;
         self
     }
 
@@ -147,19 +147,19 @@ impl<'a> WindowBuilder<'a> {
 
     /// Sets whether the background of the window should be transparent.
     pub fn with_transparency(mut self, transparent: bool) -> WindowBuilder<'a> {
-        self.attribs.transparent = transparent;
+        self.attribs.window.transparent = transparent;
         self
     }
 
     /// Sets whether the window should have a border, a title bar, etc.
     pub fn with_decorations(mut self, decorations: bool) -> WindowBuilder<'a> {
-        self.attribs.decorations = decorations;
+        self.attribs.window.decorations = decorations;
         self
     }
 
     /// Enables multitouch
     pub fn with_multitouch(mut self) -> WindowBuilder<'a> {
-        self.attribs.multitouch = true;
+        self.attribs.window.multitouch = true;
         self
     }
 
@@ -169,13 +169,13 @@ impl<'a> WindowBuilder<'a> {
     /// out of memory, etc.
     pub fn build(mut self) -> Result<Window, CreationError> {
         // resizing the window to the dimensions of the monitor when fullscreen
-        if self.attribs.dimensions.is_none() && self.attribs.monitor.is_some() {
-            self.attribs.dimensions = Some(self.attribs.monitor.as_ref().unwrap().get_dimensions())
+        if self.attribs.window.dimensions.is_none() && self.attribs.window.monitor.is_some() {
+            self.attribs.window.dimensions = Some(self.attribs.window.monitor.as_ref().unwrap().get_dimensions())
         }
 
         // default dimensions
-        if self.attribs.dimensions.is_none() {
-            self.attribs.dimensions = Some((1024, 768));
+        if self.attribs.window.dimensions.is_none() {
+            self.attribs.window.dimensions = Some((1024, 768));
         }
 
         // building


### PR DESCRIPTION
This PR removes the `BuilderAttribs` struct and replaces it with `GlAttributes`, `WindowAttributes` and `PixelFormatRequirements`.

The purpose of this change is to avoid passing windowing-related attributes to WGL/GLX/EGL, and get a better isolation.

Small breaking change: the `HeadlessRendererBuilder` now takes a lifetime parameter to store the context to share lists with.

cc #516 
~~cc #517~~