### PR TITLE
Use NSFullSizeContentViewWindowMask for decoration-less windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ objc = "0.1"
 [target.x86_64-apple-darwin.dependencies]
 objc = "0.1"
 cgl = "0"
-cocoa = "0"
+cocoa = "0.1.4"
 core-foundation = "0"
 core-graphics = "0"
 


### PR DESCRIPTION
With this, decoration-less windows look much better (proper border radius and shadows).

Depends on https://github.com/servo/cocoa-rs/pull/99/.