### PR TITLE
Make some fields in WindowBuilder and HeadlessRendererBuilder public

### DIFF
--- a/src/headless.rs
+++ b/src/headless.rs
@@ -16,9 +16,14 @@ use platform;
 
 /// Object that allows you to build headless contexts.
 pub struct HeadlessRendererBuilder<'a> {
-    dimensions: (u32, u32),
+    /// The dimensions to use.
+    pub dimensions: (u32, u32),
+
+    /// The OpenGL attributes to build the context with.
+    pub opengl: GlAttributes<&'a platform::HeadlessContext>,
+
+    // Should be made public once it's stabilized.
     pf_reqs: PixelFormatRequirements,
-    opengl: GlAttributes<&'a platform::HeadlessContext>,
 }
 
 impl<'a> HeadlessRendererBuilder<'a> {

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,9 +24,14 @@ use platform;
 
 /// Object that allows you to build windows.
 pub struct WindowBuilder<'a> {
+    /// The attributes to use to create the window.
+    pub window: WindowAttributes,
+
+    /// The attributes to use to create the context.
+    pub opengl: GlAttributes<&'a platform::Window>,
+
+    // Should be made public once it's stabilized.
     pf_reqs: PixelFormatRequirements,
-    window: WindowAttributes,
-    opengl: GlAttributes<&'a platform::Window>,
 }
 
 impl<'a> WindowBuilder<'a> {


### PR DESCRIPTION
cc #516 

Only `pf_reqs` isn't public because its members aren't stable.
