### PR TITLE
Add an `os` module containing platform-specific traits

### DIFF
--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -659,8 +659,18 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_xlib_display(&self) -> *mut libc::c_void {
+        self.x.display.display as *mut libc::c_void
+    }
+
+    #[inline]
     pub fn platform_display(&self) -> *mut libc::c_void {
         self.x.display.display as *mut libc::c_void
+    }
+
+    #[inline]
+    pub fn get_xlib_window(&self) -> *mut libc::c_void {
+        self.x.window as *mut libc::c_void
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ extern crate x11_dl;
 pub use events::*;
 pub use headless::{HeadlessRendererBuilder, HeadlessContext};
 #[cfg(feature = "window")]
-pub use window::{WindowBuilder, Window, WindowProxy, PollEventsIterator, WaitEventsIterator};
+pub use window::{WindowBuilder, WindowProxy, PollEventsIterator, WaitEventsIterator};
 #[cfg(feature = "window")]
 pub use window::{AvailableMonitorsIter, MonitorId, get_available_monitors, get_primary_monitor};
 #[cfg(feature = "window")]
@@ -77,6 +77,35 @@ mod events;
 mod headless;
 #[cfg(feature = "window")]
 mod window;
+
+pub mod os;
+
+/// Represents an OpenGL context and the Window or environment around it.
+///
+/// # Example
+///
+/// ```ignore
+/// let window = Window::new().unwrap();
+///
+/// unsafe { window.make_current() };
+///
+/// loop {
+///     for event in window.poll_events() {
+///         match(event) {
+///             // process events here
+///             _ => ()
+///         }
+///     }
+///
+///     // draw everything here
+///
+///     window.swap_buffers();
+///     std::old_io::timer::sleep(17);
+/// }
+/// ```
+pub struct Window {
+    window: platform::Window,
+}
 
 /// Trait that describes objects that have access to an OpenGL context.
 pub trait GlContext {

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,0 +1,9 @@
+//! Contains traits with platform-specific methods in them.
+//!
+//! Contains the follow modules:
+//!
+//!  - `unix`
+//!  - `windows`
+//!
+pub mod unix;
+pub mod windows;

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,0 +1,40 @@
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+
+use libc;
+use Window;
+use platform::Window as LinuxWindow;
+
+/// Additional methods on `Window` that are specific to unix.
+pub trait WindowExt {
+    /// Returns a pointer to the `Window` object of xlib that is used by this window.
+    ///
+    /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
+    ///
+    /// The pointer will become invalid when the glutin `Window` is destroyed.
+    fn get_xlib_window(&self) -> Option<*mut libc::c_void>;
+
+    /// Returns a pointer to the `Display` object of xlib that is used by this window.
+    ///
+    /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
+    ///
+    /// The pointer will become invalid when the glutin `Window` is destroyed.
+    fn get_xlib_display(&self) -> Option<*mut libc::c_void>;
+}
+
+impl WindowExt for Window {
+    #[inline]
+    fn get_xlib_window(&self) -> Option<*mut libc::c_void> {
+        match self.window {
+            LinuxWindow::X(ref w) => Some(w.get_xlib_window()),
+            _ => None
+        }
+    }
+
+    #[inline]
+    fn get_xlib_display(&self) -> Option<*mut libc::c_void> {
+        match self.window {
+            LinuxWindow::X(ref w) => Some(w.get_xlib_window()),
+            _ => None
+        }
+    }
+}

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,0 +1,21 @@
+#![cfg(target_os = "windows")]
+
+use libc;
+use Window;
+
+/// Additional methods on `Window` that are specific to unix.
+pub trait WindowExt {
+    /// Returns a pointer to the `Window` object of xlib that is used by this window.
+    ///
+    /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
+    ///
+    /// The pointer will become invalid when the glutin `Window` is destroyed.
+    fn get_hwnd(&self) -> *mut libc::c_void;
+}
+
+impl WindowExt for Window {
+    #[inline]
+    fn get_hwnd(&self) -> *mut libc::c_void {
+        self.window.platform_window()
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -14,6 +14,7 @@ use MouseCursor;
 use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
+use Window;
 use WindowAttributes;
 use native_monitor::NativeMonitorId;
 
@@ -224,32 +225,6 @@ impl<'a> WindowBuilder<'a> {
     }
 }
 
-/// Represents an OpenGL context and the Window or environment around it.
-///
-/// # Example
-///
-/// ```ignore
-/// let window = Window::new().unwrap();
-///
-/// unsafe { window.make_current() };
-///
-/// loop {
-///     for event in window.poll_events() {
-///         match(event) {
-///             // process events here
-///             _ => ()
-///         }
-///     }
-///
-///     // draw everything here
-///
-///     window.swap_buffers();
-///     std::old_io::timer::sleep(17);
-/// }
-/// ```
-pub struct Window {
-    window: platform::Window,
-}
 
 impl Default for Window {
     #[inline]
@@ -439,7 +414,7 @@ impl Window {
         self.window.swap_buffers()
     }
 
-    /// Gets the native platform specific display for this window.
+    /// DEPRECATED. Gets the native platform specific display for this window.
     /// This is typically only required when integrating with
     /// other libraries that need this information.
     #[inline]
@@ -447,7 +422,7 @@ impl Window {
         self.window.platform_display()
     }
 
-    /// Gets the native platform specific window handle. This is
+    /// DEPRECATED. Gets the native platform specific window handle. This is
     /// typically only required when integrating with other libraries
     /// that need this information.
     #[inline]


### PR DESCRIPTION
cc @glennw 

The idea is that instead of:

```rust
let window: glutin::Window = ...;
let raw = window.platform_window();
```

You do:

```rust
use glutin::os::unix::WindowExt;
let window: glutin::Window = ...;
let raw = window.get_xlib_window();
```

The previous methods still exist but are deprecated.

Close #341 (not exactly what was planned, but this is better)
