### PR TITLE
android: Disabled multitouch by default

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -133,6 +133,7 @@ impl Window {
 
         let (tx, rx) = channel();
         android_glue::add_sender(tx);
+        android_glue::set_multitouch(win_attribs.multitouch);
 
         Ok(Window {
             context: context,


### PR DESCRIPTION
Depends on https://github.com/tomaka/android-rs-glue/pull/66