### PR TITLE
ensure server has GLX_ARB_create_context extension

### DIFF
--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -260,7 +260,7 @@ fn create_context(glx: &ffi::glx::Glx, extra_functions: &ffi::glx_extra::Glx, ex
                   -> Result<ffi::GLXContext, CreationError>
 {
     unsafe {
-        let context = if extra_functions.CreateContextAttribsARB.is_loaded() {
+        let context = if extensions.split(' ').find(|&i| i == "GLX_ARB_create_context").is_some() {
             let mut attributes = Vec::with_capacity(9);
 
             attributes.push(ffi::glx_extra::CONTEXT_MAJOR_VERSION_ARB as libc::c_int);


### PR DESCRIPTION
Somehow, my machine (running Ubuntu 12.04) only has GLX_ARB_create_context on the client, which made all the examples fail with BadRequest when they tried to create a window.