### PR TITLE
Change X11 events based on `multitouch` option

### DIFF
--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -562,7 +562,7 @@ impl Window {
             current_size: Cell::new((0, 0)),
             pending_events: Mutex::new(VecDeque::new()),
             cursor_state: Mutex::new(CursorState::Normal),
-            input_handler: Mutex::new(XInputEventHandler::new(display, window, ic))
+            input_handler: Mutex::new(XInputEventHandler::new(display, window, ic, window_attrs))
         };
 
         // returning


### PR DESCRIPTION
* If `multitouch` is enabled, touch input generates touch events.
* If `multitouch` is disabled, touch input generates emulated mouse events.