### PR TITLE
Improve fullscreen example

### DIFF
--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -4,7 +4,7 @@ extern crate android_glue;
 
 extern crate glutin;
 
-use std::io;
+use std::io::{self, Write};
 
 mod support;
 
@@ -19,6 +19,7 @@ fn main() {
         }
 
         print!("Please write the number of the monitor to use: ");
+        io::stdout().flush().unwrap();
 
         let mut num = String::new();
         io::stdin().read_line(&mut num).unwrap();

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -50,6 +50,7 @@ fn main() {
 
         match event {
             glutin::Event::Closed => break,
+            glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) => break,
             _ => ()
         }
     }


### PR DESCRIPTION
Two semantic changes here:
* The prompt to choose a monitor wasn't being flushed, and I fixed that.
* I added the ability to exit the example using <kbd>Esc</kbd>, as requested in issue #543.