### PR TITLE
Fix fullscreen on X11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,39 +85,39 @@ osmesa-sys = "0.0.5"
 wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
 wayland-window = "0.1.0"
-x11-dl = "~2.0"
+x11-dl = "~2.2"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
 wayland-window = "0.1.0"
-x11-dl = "~2.0"
+x11-dl = "~2.2"
 
 [target.arm-unknown-linux-gnueabihf.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
 wayland-window = "0.1.0"
-x11-dl = "~2.0"
+x11-dl = "~2.2"
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
 wayland-window = "0.1.0"
-x11-dl = "~2.0"
+x11-dl = "~2.2"
 
 [target.x86_64-unknown-dragonfly.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
 wayland-window = "0.1.0"
-x11-dl = "~2.0"
+x11-dl = "~2.2"
 
 [target.x86_64-unknown-freebsd.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.2.1", features = ["egl", "dlopen"] }
 wayland-kbd = "0.2.0"
 wayland-window = "0.1.0"
-x11-dl = "~2.0"
+x11-dl = "~2.2"

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -565,6 +565,16 @@ impl Window {
             input_handler: Mutex::new(XInputEventHandler::new(display, window, ic, window_attrs))
         };
 
+        unsafe {
+            let ref x_window: &XWindow = window.x.borrow();
+            (display.xlib.XSetInputFocus)(
+                display.display,
+                x_window.window,
+                ffi::RevertToParent,
+                ffi::CurrentTime
+            );
+        }
+
         // returning
         Ok(window)
     }

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -333,7 +333,7 @@ impl Window {
                 } else {
                     let m = (0 .. mode_num).map(|i| {
                         let m: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as isize) as *const _); m
-                    }).find(|m| m.hdisplay >= dimensions.0 as u16 && m.vdisplay == dimensions.1 as u16);
+                    }).find(|m| m.hdisplay >= dimensions.0 as u16 && m.vdisplay >= dimensions.1 as u16);
 
                     match m {
                         Some(m) => Some(m),

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -435,16 +435,6 @@ impl Window {
             window_attributes |= ffi::CWBackPixel;
         }
 
-        // switching to fullscreen
-        // if let Some(mut mode_to_switch_to) = mode_to_switch_to {
-        //     window_attributes |= ffi::CWOverrideRedirect;
-        //     unsafe {
-        //         (display.xf86vmode.XF86VidModeSwitchToMode)(display.display, screen_id, &mut mode_to_switch_to);
-        //         (display.xf86vmode.XF86VidModeSetViewPort)(display.display, screen_id, 0, 0);
-        //         set_win_attr.override_redirect = 1;
-        //     }
-        // }
-
         // finally creating the window
         let window = unsafe {
             let win = (display.xlib.XCreateWindow)(display.display, root, 0, 0, dimensions.0 as libc::c_uint,
@@ -570,6 +560,22 @@ impl Window {
                     ffi::SubstructureRedirectMask | ffi::SubstructureNotifyMask,
                     &mut x_event as *mut _
                 );
+            }
+
+            if let Some(mut mode_to_switch_to) = mode_to_switch_to {
+                unsafe {
+                    (display.xf86vmode.XF86VidModeSwitchToMode)(
+                        display.display,
+                        screen_id,
+                        &mut mode_to_switch_to
+                    );
+                }
+            }
+            else {
+                println!("[glutin] Unexpected state: `mode` is None creating fullscreen window");
+            }
+            unsafe {
+                (display.xf86vmode.XF86VidModeSetViewPort)(display.display, screen_id, 0, 0);
             }
         }
 

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -325,7 +325,7 @@ impl Window {
             let mode_to_switch_to = if window_attrs.monitor.is_some() {
                 let matching_mode = (0 .. mode_num).map(|i| {
                     let m: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as isize) as *const _); m
-                }).find(|m| m.hdisplay == dimensions.0 as u16 && m.vsyncstart == dimensions.1 as u16);
+                }).find(|m| m.hdisplay == dimensions.0 as u16 && m.vdisplay == dimensions.1 as u16);
 
                 if let Some(matching_mode) = matching_mode {
                     Some(matching_mode)
@@ -333,7 +333,7 @@ impl Window {
                 } else {
                     let m = (0 .. mode_num).map(|i| {
                         let m: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as isize) as *const _); m
-                    }).find(|m| m.hdisplay >= dimensions.0 as u16 && m.vsyncstart == dimensions.1 as u16);
+                    }).find(|m| m.hdisplay >= dimensions.0 as u16 && m.vdisplay == dimensions.1 as u16);
 
                     match m {
                         Some(m) => Some(m),

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -535,11 +535,7 @@ impl Window {
                 message_type: state_atom, // the _NET_WM_STATE atom is sent to change the state of a window
                 format: 32,               // view `data` as `c_long`s
                 data: {
-                    // TODO replace this with normal instantiation when x11-rs makes
-                    // ClientMessageData instantiable.
-                    let mut data = unsafe {
-                        mem::transmute::<[libc::c_long; 5], ffi::ClientMessageData>([0; 5])
-                    };
+                    let mut data = ffi::ClientMessageData::new();
                     // This first `long` is the action; `1` means add/set following property.
                     data.set_long(0, 1);
                     // This second `long` is the property to set (fullscreen)

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -319,9 +319,6 @@ impl Window {
 
             let xf86_desk_mode = *modes.offset(0);
 
-            // FIXME: `XF86VidModeModeInfo` is missing its `hskew` field. Therefore we point to
-            //        `vsyncstart` instead of `vdisplay` as a temporary hack.
-
             let mode_to_switch_to = if window_attrs.monitor.is_some() {
                 let matching_mode = (0 .. mode_num).map(|i| {
                     let m: ffi::XF86VidModeModeInfo = ptr::read(*modes.offset(i as isize) as *const _); m


### PR DESCRIPTION
Two semantic changes:
* Use `vdisplay` again instead of `vsyncstart`
* Focus newly created windows

I know there was some reason you were using `vsyncstart` instead of `vdisplay`, but I couldn't figure it out from Googling around. (I have no idea what I'm doing.) It is of note, however, that Rust's X11 bindings shouldn't be missing `XF86VidModeModeInfo::hskew` anymore. (Daggerbot/x11-rs#19)