### PR TITLE
Change some uses of c_void to avoid libc version conflicts.

### DIFF
--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -89,7 +89,7 @@ impl GlContext for OsMesaContext {
     #[inline]
     unsafe fn make_current(&self) -> Result<(), ContextError> {
         let ret = osmesa_sys::OSMesaMakeCurrent(self.context, self.buffer.as_ptr()
-                                                as *mut libc::c_void, 0x1401, self.width
+                                                as *mut _, 0x1401, self.width
                                                 as libc::c_int, self.height as libc::c_int);
 
         // an error can only happen in case of invalid parameter, which would indicate a bug

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -354,8 +354,8 @@ impl Window {
             Glx(::api::glx::ContextPrototype<'a>),
             Egl(::api::egl::ContextPrototype<'a>),
         }
-        let builder_clone_opengl_glx = opengl.clone().map_sharing(|_| unimplemented!());      // FIXME: 
-        let builder_clone_opengl_egl = opengl.clone().map_sharing(|_| unimplemented!());      // FIXME: 
+        let builder_clone_opengl_glx = opengl.clone().map_sharing(|_| unimplemented!());      // FIXME:
+        let builder_clone_opengl_egl = opengl.clone().map_sharing(|_| unimplemented!());      // FIXME:
         let context = match opengl.version {
             GlRequest::Latest | GlRequest::Specific(Api::OpenGl, _) | GlRequest::GlThenGles { .. } => {
                 // GLX should be preferred over EGL, otherwise crashes may occur
@@ -521,7 +521,7 @@ impl Window {
                 (*hint).res_name = c_name as *mut libc::c_char;
                 (*hint).res_class = c_name as *mut libc::c_char;
                 (display.xlib.XSetClassHint)(display.display, window, hint);
-                (display.xlib.XFree)(hint as *mut libc::c_void);
+                (display.xlib.XFree)(hint as *mut _);
             });
         }
 


### PR DESCRIPTION
This will also allow us to remove dependence on `libc` in `osmesa-sys`.