### PR TITLE
Update to libc 0.2, remove unnecessary gl_common crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ build = "build.rs"
 [dependencies]
 gl_common = "0.1.0"
 lazy_static = "0.1.10"
-libc = "0.1"
+libc = "0.2"
 shared_library = "0.1.0"
 
 [build-dependencies]
-gl_generator = "0.1.0"
+gl_generator = "0.2.0"
 khronos_api = "0.0.8"
 
 [dev-dependencies]
@@ -27,22 +27,22 @@ clock_ticks = "0.1.0"
 version = "0.1"
 
 [target.i386-apple-ios.dependencies]
-objc = ">=0.1.0, <=0.1.7"
+objc = "0.1.8"
 
 [target.x86_64-apple-ios.dependencies]
-objc = ">=0.1.0, <=0.1.7"
+objc = "0.1.8"
 
 [target.aarch64-apple-ios.dependencies]
-objc = ">=0.1.0, <=0.1.7"
+objc = "0.1.8"
 
 [target.armv7s-apple-ios.dependencies]
-objc = ">=0.1.0, <=0.1.7"
+objc = "0.1.8"
 
 [target.armv7-apple-ios.dependencies]
-objc = ">=0.1.0, <=0.1.7"
+objc = "0.1.8"
 
 [target.x86_64-apple-darwin.dependencies]
-objc = ">=0.1.0, <=0.1.7"
+objc = "0.1.8"
 cgl = "0.1"
 cocoa = "0.1.4"
 core-foundation = "0"
@@ -53,7 +53,7 @@ winapi = "0.2"
 shell32-sys = "0.1"
 gdi32-sys = "0.1"
 user32-sys = "~0.1.2"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2"
 dwmapi-sys = "0.1"
 
 [target.i686-pc-windows-msvc.dependencies]
@@ -61,7 +61,7 @@ winapi = "0.2"
 shell32-sys = "0.1"
 gdi32-sys = "0.1"
 user32-sys = "~0.1.2"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2"
 dwmapi-sys = "0.1"
 
 [target.x86_64-pc-windows-gnu.dependencies]
@@ -69,7 +69,7 @@ winapi = "0.2"
 shell32-sys = "0.1"
 gdi32-sys = "0.1"
 user32-sys = "~0.1.2"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2"
 dwmapi-sys = "0.1"
 
 [target.x86_64-pc-windows-msvc.dependencies]
@@ -77,7 +77,7 @@ winapi = "0.2"
 shell32-sys = "0.1"
 gdi32-sys = "0.1"
 user32-sys = "~0.1.2"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2"
 dwmapi-sys = "0.1"
 
 [target.i686-unknown-linux-gnu.dependencies]

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -13,7 +13,7 @@ pub struct Context {
 }
 
 pub fn load(window: &glutin::Window) -> Context {
-    let gl = gl::Gl::load(window);
+    let gl = gl::Gl::load_with(|s| window.get_proc_address(s));
 
     let version = unsafe {
         let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const _).to_bytes().to_vec();

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -8,7 +8,6 @@ use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
 
-use gl_common;
 use libc;
 
 use platform;
@@ -117,13 +116,6 @@ impl HeadlessContext {
 
     #[inline]
     pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {
-    }
-}
-
-impl gl_common::GlFunctionsSource for HeadlessContext {
-    #[inline]
-    fn get_proc_addr(&self, addr: &str) -> *const libc::c_void {
-        self.get_proc_address(addr)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ extern crate lazy_static;
 #[macro_use]
 extern crate shared_library;
 
-extern crate gl_common;
 extern crate libc;
 
 #[cfg(target_os = "windows")]

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,7 +18,6 @@ use Window;
 use WindowAttributes;
 use native_monitor::NativeMonitorId;
 
-use gl_common;
 use libc;
 
 use platform;
@@ -489,13 +488,6 @@ impl Window {
     #[inline]
     pub fn set_cursor_state(&self, state: CursorState) -> Result<(), String> {
         self.window.set_cursor_state(state)
-    }
-}
-
-impl gl_common::GlFunctionsSource for Window {
-    #[inline]
-    fn get_proc_addr(&self, addr: &str) -> *const libc::c_void {
-        self.get_proc_address(addr)
     }
 }
 


### PR DESCRIPTION
I thought I'd open up another PR branch (an alternative to #655) that attempts to update to libc 0.2 and removes the gl_common dependency.

This build succeeds locally on OSX.

@tomaka I don't have a thorough understanding on what gl_common's original role was, however I noticed that you recently removed it from gl-rs, so I thought it might no longer have a place here - let me know if I was wrong and this should be done another way!