### PR TITLE
Minimum/maximum dimensions for windows in win32 API

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -120,6 +120,10 @@ impl Window {
     {
         use std::{mem, ptr};
 
+        // not implemented
+        assert!(win_attribs.min_dimensions.is_none());
+        assert!(win_attribs.max_dimensions.is_none());
+
         let opengl = opengl.clone().map_sharing(|w| &w.context);
 
         let native_window = unsafe { android_glue::get_native_window() };

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -268,6 +268,10 @@ impl Window {
             unimplemented!()
         }
 
+        // not implemented
+        assert!(win_attribs.min_dimensions.is_none());
+        assert!(win_attribs.max_dimensions.is_none());
+
         match opengl.robustness {
             Robustness::RobustNoResetNotification | Robustness::RobustLoseContextOnReset => {
                 return Err(CreationError::RobustnessNotSupported);

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -257,6 +257,10 @@ impl Window {
     {
         use self::wayland::internals::FFI;
 
+        // not implemented
+        assert!(win_attribs.min_dimensions.is_none());
+        assert!(win_attribs.max_dimensions.is_none());
+
         let wayland_context = match *WAYLAND_CONTEXT {
             Some(ref c) => c,
             None => return Err(CreationError::NotSupported),

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -258,8 +258,8 @@ impl Window {
         use self::wayland::internals::FFI;
 
         // not implemented
-        assert!(win_attribs.min_dimensions.is_none());
-        assert!(win_attribs.max_dimensions.is_none());
+        assert!(window.min_dimensions.is_none());
+        assert!(window.max_dimensions.is_none());
 
         let wayland_context = match *WAYLAND_CONTEXT {
             Some(ref c) => c,

--- a/src/api/win32/callback.rs
+++ b/src/api/win32/callback.rs
@@ -10,6 +10,7 @@ use WindowAttributes;
 use CursorState;
 use Event;
 use super::event;
+use super::WindowState;
 
 use user32;
 use shell32;
@@ -19,13 +20,6 @@ use winapi;
 /// its context (the HWND, the Sender for events, etc.) stashed in
 /// a thread-local variable.
 thread_local!(pub static CONTEXT_STASH: RefCell<Option<ThreadLocalData>> = RefCell::new(None));
-
-/// Contains information about states and the window for the callback.
-#[derive(Clone)]
-pub struct WindowState {
-    pub cursor_state: CursorState,
-    pub attributes: WindowAttributes
-}
 
 pub struct ThreadLocalData {
     pub win: winapi::HWND,
@@ -257,7 +251,7 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
                 let cstash = cstash.as_ref();
                 // there's a very bizarre borrow checker bug
                 // possibly related to rust-lang/rust/#23338
-                let _window_state = if let Some(cstash) = cstash {
+                let _cursor_state = if let Some(cstash) = cstash {
                     if let Ok(window_state) = cstash.window_state.lock() {
                         match window_state.cursor_state {
                             CursorState::Normal => {

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::thread;
 
 use super::callback;
-use super::callback::WindowState;
+use super::WindowState;
 use super::Window;
 use super::MonitorId;
 use super::WindowWrapper;
@@ -215,8 +215,11 @@ unsafe fn init(title: Vec<u16>, window: &WindowAttributes, pf_reqs: &PixelFormat
         user32::SetForegroundWindow(real_window.0);
     }
 
-    // Creating a mutex to track the current cursor state
-    let cursor_state = CursorState::Normal;
+    // Creating a mutex to track the current window state
+    let window_state = Arc::new(Mutex::new(WindowState {
+        cursor_state: CursorState::Normal,
+        attributes: window.clone()
+    }));
 
     // filling the CONTEXT_STASH task-local storage so that we can start receiving events
     let events_receiver = {
@@ -226,10 +229,7 @@ unsafe fn init(title: Vec<u16>, window: &WindowAttributes, pf_reqs: &PixelFormat
             let data = callback::ThreadLocalData {
                 win: real_window.0,
                 sender: tx.take().unwrap(),
-                window_state: Arc::new(Mutex::new(WindowState {
-                    cursor_state: cursor_state.clone(),
-                    attributes: window.clone()
-                }))
+                window_state: window_state.clone()
             };
             (*context_stash.borrow_mut()) = Some(data);
         });
@@ -241,7 +241,7 @@ unsafe fn init(title: Vec<u16>, window: &WindowAttributes, pf_reqs: &PixelFormat
         window: real_window,
         context: context,
         events_receiver: events_receiver,
-        cursor_state: cursor_state,
+        window_state: window_state,
     })
 }
 

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -5,6 +5,7 @@ use std::mem;
 use std::thread;
 
 use super::callback;
+use super::callback::WindowState;
 use super::Window;
 use super::MonitorId;
 use super::WindowWrapper;
@@ -215,7 +216,7 @@ unsafe fn init(title: Vec<u16>, window: &WindowAttributes, pf_reqs: &PixelFormat
     }
 
     // Creating a mutex to track the current cursor state
-    let cursor_state = Arc::new(Mutex::new(CursorState::Normal));
+    let cursor_state = CursorState::Normal;
 
     // filling the CONTEXT_STASH task-local storage so that we can start receiving events
     let events_receiver = {
@@ -225,7 +226,10 @@ unsafe fn init(title: Vec<u16>, window: &WindowAttributes, pf_reqs: &PixelFormat
             let data = callback::ThreadLocalData {
                 win: real_window.0,
                 sender: tx.take().unwrap(),
-                cursor_state: cursor_state.clone()
+                window_state: Arc::new(Mutex::new(WindowState {
+                    cursor_state: cursor_state.clone(),
+                    attributes: window.clone()
+                }))
             };
             (*context_stash.borrow_mut()) = Some(data);
         });

--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -42,6 +42,13 @@ lazy_static! {
     static ref WAKEUP_MSG_ID: u32 = unsafe { user32::RegisterWindowMessageA("Glutin::EventID".as_ptr() as *const i8) };
 }
 
+/// Contains information about states and the window for the callback.
+#[derive(Clone)]
+pub struct WindowState {
+    pub cursor_state: CursorState,
+    pub attributes: WindowAttributes
+}
+
 /// The Win32 implementation of the main `Window` object.
 pub struct Window {
     /// Main handle for the window.
@@ -53,8 +60,8 @@ pub struct Window {
     /// Receiver for the events dispatched by the window callback.
     events_receiver: Receiver<Event>,
 
-    /// The current cursor state.
-    cursor_state: CursorState,
+    /// The current window state.
+    window_state: Arc<Mutex<WindowState>>,
 }
 
 unsafe impl Send for Window {}
@@ -258,7 +265,7 @@ impl Window {
     }
 
     pub fn set_cursor_state(&self, state: CursorState) -> Result<(), String> {
-        let mut current_state = self.cursor_state;
+        let mut current_state = self.window_state.lock().unwrap().cursor_state;
 
         let foreground_thread_id = unsafe { user32::GetWindowThreadProcessId(self.window.0, ptr::null_mut()) };
         let current_thread_id = unsafe { kernel32::GetCurrentThreadId() };

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -305,8 +305,8 @@ impl Window {
         let dimensions = window_attrs.dimensions.unwrap_or((800, 600));
 
         // not implemented
-        assert!(win_attribs.min_dimensions.is_none());
-        assert!(win_attribs.max_dimensions.is_none());
+        assert!(window_attrs.min_dimensions.is_none());
+        assert!(window_attrs.max_dimensions.is_none());
 
         let screen_id = match window_attrs.monitor {
             Some(PlatformMonitorId::X(MonitorId(_, monitor))) => monitor as i32,

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -304,6 +304,10 @@ impl Window {
     {
         let dimensions = window_attrs.dimensions.unwrap_or((800, 600));
 
+        // not implemented
+        assert!(win_attribs.min_dimensions.is_none());
+        assert!(win_attribs.max_dimensions.is_none());
+
         let screen_id = match window_attrs.monitor {
             Some(PlatformMonitorId::X(MonitorId(_, monitor))) => monitor as i32,
             _ => unsafe { (display.xlib.XDefaultScreen)(display.display) },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,6 +527,16 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub dimensions: Option<(u32, u32)>,
 
+    /// The minimum dimensions a window can be, If this is `None`, the minimum will be set to 800x600.
+    ///
+    /// The default is `None`.
+    pub min_dimensions: Option<(u32, u32)>,
+
+    /// The maximum dimensions a window can be, If this is `None`, the maximum will be the dimensions of the primary monitor.
+    ///
+    /// The default is `None`.
+    pub max_dimensions: Option<(u32, u32)>,
+
     /// If `Some`, the window will be in fullscreen mode with the given monitor.
     ///
     /// The default is `None`.
@@ -563,6 +573,8 @@ impl Default for WindowAttributes {
     fn default() -> WindowAttributes {
         WindowAttributes {
             dimensions: None,
+            min_dimensions: None,
+            max_dimensions: None,
             monitor: None,
             title: "glutin window".to_owned(),
             visible: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,12 +527,12 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub dimensions: Option<(u32, u32)>,
 
-    /// The minimum dimensions a window can be, If this is `None`, the minimum will be set to 800x600.
+    /// The minimum dimensions a window can be, If this is `None`, the window will have no minimum dimensions (aside from reserved).
     ///
     /// The default is `None`.
     pub min_dimensions: Option<(u32, u32)>,
 
-    /// The maximum dimensions a window can be, If this is `None`, the maximum will be the dimensions of the primary monitor.
+    /// The maximum dimensions a window can be, If this is `None`, the maximum will have no maximum or will be set to the primary monitor's dimensions by the platform.
     ///
     /// The default is `None`.
     pub max_dimensions: Option<(u32, u32)>,

--- a/src/window.rs
+++ b/src/window.rs
@@ -52,6 +52,24 @@ impl<'a> WindowBuilder<'a> {
         self.window.dimensions = Some((width, height));
         self
     }
+    
+    /// Sets a minimum dimension size for the window
+    ///
+    /// Width and height are in pixels.
+    #[inline]
+    pub fn with_min_dimensions(mut self, width: u32, height: u32) -> WindowBuilder<'a> {
+        self.window.min_dimensions = Some((width, height));
+        self
+    }
+
+    /// Sets a maximum dimension size for the window
+    ///
+    /// Width and height are in pixels.
+    #[inline]
+    pub fn with_max_dimensions(mut self, width: u32, height: u32) -> WindowBuilder<'a> {
+        self.window.max_dimensions = Some((width, height));
+        self
+    }
 
     /// Requests a specific title for the window.
     #[inline]


### PR DESCRIPTION
Prevents the user from resizing lower/higher than minimum/maximum dimensions of the window. Also changes CursorState to WindowState.