### PR TITLE
Fix compilation for 32 bit targets

### DIFF
--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -8,6 +8,7 @@ use std::cell::Cell;
 use std::sync::atomic::AtomicBool;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+use std::os::raw::c_long;
 
 use Api;
 use ContextError;
@@ -539,7 +540,7 @@ impl Window {
                     // This first `long` is the action; `1` means add/set following property.
                     data.set_long(0, 1);
                     // This second `long` is the property to set (fullscreen)
-                    data.set_long(1, fullscreen_atom as i64);
+                    data.set_long(1, fullscreen_atom as c_long);
                     data
                 }
             };


### PR DESCRIPTION
Regression introduced in 47df0e9eaa7f1231a07f86fc44426936c7a2589a

Casting fullscreen_atom (which is the result from XInternAtom, i.e.
c_ulong) as i64 is obviously wrong -- the whole point of types such as
c_ulong is that long in C does *not* always have the same bit size...

Cast it as c_long instead.

While this is the most straightforward fix, I'm not sure it's the best
one: perhaps the x11 crate should offer a set_ulong() method along with
set_long(), which could be used here instead of the cast?