### PR TITLE
Add better X error handling

### DIFF
--- a/src/api/x11/mod.rs
+++ b/src/api/x11/mod.rs
@@ -2,7 +2,7 @@
 
 pub use self::monitor::{MonitorId, get_available_monitors, get_primary_monitor};
 pub use self::window::{Window, XWindow, PollEventsIterator, WaitEventsIterator, Context, WindowProxy};
-pub use self::xdisplay::{XConnection, XNotSupported};
+pub use self::xdisplay::{XConnection, XNotSupported, XError};
 
 pub mod ffi;
 

--- a/src/api/x11/monitor.rs
+++ b/src/api/x11/monitor.rs
@@ -9,6 +9,7 @@ pub struct MonitorId(pub Arc<XConnection>, pub u32);
 
 pub fn get_available_monitors(x: &Arc<XConnection>) -> VecDeque<MonitorId> {
     let nb_monitors = unsafe { (x.xlib.XScreenCount)(x.display) };
+    x.check_errors().expect("Failed to call XScreenCount");
 
     let mut monitors = VecDeque::new();
     monitors.extend((0 .. nb_monitors).map(|i| MonitorId(x.clone(), i as u32)));
@@ -18,6 +19,7 @@ pub fn get_available_monitors(x: &Arc<XConnection>) -> VecDeque<MonitorId> {
 #[inline]
 pub fn get_primary_monitor(x: &Arc<XConnection>) -> MonitorId {
     let primary_monitor = unsafe { (x.xlib.XDefaultScreen)(x.display) };
+    x.check_errors().expect("Failed to call XDefaultScreen");
     MonitorId(x.clone(), primary_monitor as u32)
 }
 
@@ -36,6 +38,7 @@ impl MonitorId {
         let screen = unsafe { (self.0.xlib.XScreenOfDisplay)(self.0.display, self.1 as i32) };
         let width = unsafe { (self.0.xlib.XWidthOfScreen)(screen) };
         let height = unsafe { (self.0.xlib.XHeightOfScreen)(screen) };
+        self.0.check_errors().expect("Failed to get monitor dimensions");
         (width as u32, height as u32)
     }
 }


### PR DESCRIPTION
Stores an `Option<XError>` inside the `XConnection`.

The error callback fills this member whenever an error occurs.
Its content is then checked after each operation.
