### PR TITLE
Support HiDPI on Linux by querying the Xft DPI through XSETTINGS.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/tomaka/glutin"
 documentation = "https://tomaka.github.io/glutin/"
 build = "build.rs"
 
+[features]
+default = []
+use-xsettings = ["xsettings"]
+
 [dependencies]
 lazy_static = "0.1.10"
 libc = "0.2"
@@ -86,12 +90,20 @@ wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.3"
 
+[target.i686-unknown-linux-gnu.dependencies.xsettings]
+version = "0.2"
+optional = true
+
 [target.x86_64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
 wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.3"
+
+[target.x86_64-unknown-linux-gnu.dependencies.xsettings]
+version = "0.2"
+optional = true
 
 [target.arm-unknown-linux-gnueabihf.dependencies]
 osmesa-sys = "0.0.5"
@@ -100,12 +112,20 @@ wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.3"
 
+[target.arm-unknown-linux-gnueabihf.dependencies.xsettings]
+version = "0.2"
+optional = true
+
 [target.aarch64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
 wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.3"
+
+[target.aarch64-unknown-linux-gnu.dependencies.xsettings]
+version = "0.2"
+optional = true
 
 [target.x86_64-unknown-dragonfly.dependencies]
 osmesa-sys = "0.0.5"
@@ -114,9 +134,18 @@ wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.3"
 
+[target.x86_64-unknown-dragonfly.dependencies.xsettings]
+version = "0.2"
+optional = true
+
 [target.x86_64-unknown-freebsd.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
 wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.3"
+
+[target.x86_64-unknown-freebsd.dependencies.xsettings]
+version = "0.2"
+optional = true
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ extern crate x11_dl;
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"))]
 #[macro_use(wayland_env)]
 extern crate wayland_client;
+#[cfg(all(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"),
+          feature = "use-xsettings"))]
+extern crate xsettings;
 
 pub use events::*;
 pub use headless::{HeadlessRendererBuilder, HeadlessContext};


### PR DESCRIPTION
The Xft DPI is set when the user adjusts the scale in the Ubuntu
"Displays" preference pane.

This depends on `rust-xsettings`, which in turn uses the C library
`libxsettings-client-0`. Unfortunately, this library is not installed by
default on most Linux distributions. To avoid unnecessary dependencies,
this commit places support for HiDPI on Linux behind the `use-xsettings`
Cargo feature.
