### PR TITLE
Unlocks platform-specific attributes

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -65,6 +65,11 @@ impl MonitorId {
     }
 }
 
+#[derive(Default)]
+pub struct PlatformSpecificWindowBuilderAttributes;
+#[derive(Default)]
+pub struct PlatformSpecificHeadlessBuilderAttributes;
+
 pub struct PollEventsIterator<'a> {
     window: &'a Window,
 }
@@ -116,7 +121,8 @@ impl<'a> Iterator for WaitEventsIterator<'a> {
 
 impl Window {
     pub fn new(win_attribs: &WindowAttributes, pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&Window>) -> Result<Window, CreationError>
+               opengl: &GlAttributes<&Window>, _: &PlatformSpecificWindowBuilderAttributes)
+               -> Result<Window, CreationError>
     {
         use std::{mem, ptr};
 
@@ -302,7 +308,9 @@ pub struct HeadlessContext(EglContext);
 impl HeadlessContext {
     /// See the docs in the crate root file.
     pub fn new(dimensions: (u32, u32), pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&HeadlessContext>) -> Result<HeadlessContext, CreationError>
+               opengl: &GlAttributes<&HeadlessContext>,
+               _: &PlatformSpecificHeadlessBuilderAttributes)
+               -> Result<HeadlessContext, CreationError>
     {
         let opengl = opengl.clone().map_sharing(|c| &c.0);
         let context = try!(EglContext::new(egl::ffi::egl::Egl, pf_reqs, &opengl,

--- a/src/api/cocoa/headless.rs
+++ b/src/api/cocoa/headless.rs
@@ -13,6 +13,9 @@ use cocoa::appkit::*;
 use PixelFormat;
 use api::cocoa::helpers;
 
+#[derive(Default)]
+pub struct PlatformSpecificHeadlessBuilderAttributes;
+
 pub struct HeadlessContext {
     width: u32,
     height: u32,
@@ -21,7 +24,9 @@ pub struct HeadlessContext {
 
 impl HeadlessContext {
     pub fn new((width, height): (u32, u32), pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&HeadlessContext>) -> Result<HeadlessContext, CreationError>
+               opengl: &GlAttributes<&HeadlessContext>,
+               _: &PlatformSpecificHeadlessBuilderAttributes)
+               -> Result<HeadlessContext, CreationError>
     {
         let context = unsafe {
 

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -1,7 +1,5 @@
 #![cfg(target_os = "macos")]
 
-pub use self::headless::HeadlessContext;
-
 use {CreationError, Event, MouseCursor, CursorState};
 use CreationError::OsError;
 use libc;
@@ -50,6 +48,8 @@ use events::MouseButton;
 use events;
 
 pub use self::monitor::{MonitorId, get_available_monitors, get_primary_monitor};
+pub use self::headless::HeadlessContext;
+pub use self::headless::PlatformSpecificHeadlessBuilderAttributes;
 
 mod monitor;
 mod event;
@@ -179,6 +179,9 @@ impl Drop for WindowDelegate {
     }
 }
 
+#[derive(Default)]
+pub struct PlatformSpecificWindowBuilderAttributes;
+
 pub struct Window {
     view: IdRef,
     window: IdRef,
@@ -264,7 +267,8 @@ impl<'a> Iterator for WaitEventsIterator<'a> {
 
 impl Window {
     pub fn new(win_attribs: &WindowAttributes, pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&Window>) -> Result<Window, CreationError>
+               opengl: &GlAttributes<&Window>, _: &PlatformSpecificWindowBuilderAttributes)
+               -> Result<Window, CreationError>
     {
         if opengl.sharing.is_some() {
             unimplemented!()

--- a/src/api/ios/mod.rs
+++ b/src/api/ios/mod.rs
@@ -177,10 +177,14 @@ impl MonitorId {
     }
 }
 
+#[derive(Default)]
+pub struct PlatformSpecificWindowBuilderAttributes;
 
 impl Window {
 
-    pub fn new(builder: &WindowAttributes, _: &PixelFormatRequirements, _: &GlAttributes<&Window>) -> Result<Window, CreationError> {
+    pub fn new(builder: &WindowAttributes, _: &PixelFormatRequirements, _: &GlAttributes<&Window>,
+               _: &PlatformSpecificWindowBuilderAttributes) -> Result<Window, CreationError>
+    {
         unsafe {
             if setjmp(mem::transmute(&mut jmpbuf)) != 0 {
                 let app: id = msg_send![Class::get("UIApplication").unwrap(), sharedApplication];

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -20,6 +20,9 @@ pub struct HeadlessRendererBuilder<'a> {
 
     // Should be made public once it's stabilized.
     pf_reqs: PixelFormatRequirements,
+
+    /// Platform-specific configuration.
+    platform_specific: platform::PlatformSpecificHeadlessBuilderAttributes,
 }
 
 impl<'a> HeadlessRendererBuilder<'a> {
@@ -30,6 +33,7 @@ impl<'a> HeadlessRendererBuilder<'a> {
             dimensions: (width, height),
             pf_reqs: Default::default(),
             opengl: Default::default(),
+            platform_specific: Default::default(),
         }
     }
 
@@ -63,7 +67,8 @@ impl<'a> HeadlessRendererBuilder<'a> {
     ///  out of memory, etc.
     #[inline]
     pub fn build(self) -> Result<HeadlessContext, CreationError> {
-        platform::HeadlessContext::new(self.dimensions, &self.pf_reqs, &self.opengl)
+        platform::HeadlessContext::new(self.dimensions, &self.pf_reqs, &self.opengl,
+                                       &self.platform_specific)
                 .map(|w| HeadlessContext { context: w })
     }
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -3,8 +3,9 @@
 use libc;
 use Window;
 use platform::Window as LinuxWindow;
+use WindowBuilder;
 
-/// Additional methods on `Window` that are specific to unix.
+/// Additional methods on `Window` that are specific to Unix.
 pub trait WindowExt {
     /// Returns a pointer to the `Window` object of xlib that is used by this window.
     ///
@@ -37,4 +38,12 @@ impl WindowExt for Window {
             _ => None
         }
     }
+}
+
+/// Additional methods on `WindowBuilder` that are specific to Unix.
+pub trait WindowBuilderExt {
+
+}
+
+impl<'a> WindowBuilderExt for WindowBuilder<'a> {
 }

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -2,8 +2,9 @@
 
 use libc;
 use Window;
+use WindowBuilder;
 
-/// Additional methods on `Window` that are specific to unix.
+/// Additional methods on `Window` that are specific to Windows.
 pub trait WindowExt {
     /// Returns a pointer to the `Window` object of xlib that is used by this window.
     ///
@@ -18,4 +19,12 @@ impl WindowExt for Window {
     fn get_hwnd(&self) -> *mut libc::c_void {
         self.window.platform_window()
     }
+}
+
+/// Additional methods on `WindowBuilder` that are specific to Windows.
+pub trait WindowBuilderExt {
+
+}
+
+impl<'a> WindowBuilderExt for WindowBuilder<'a> {
 }

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -57,3 +57,8 @@ impl GlContext for HeadlessContext {
 
 unsafe impl Send for HeadlessContext {}
 unsafe impl Sync for HeadlessContext {}
+
+#[derive(Default)]
+pub struct PlatformSpecificWindowBuilderAttributes;
+#[derive(Default)]
+pub struct PlatformSpecificHeadlessBuilderAttributes;

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -8,12 +8,17 @@ use ContextError;
 
 pub use api::ios::*;
 
+#[derive(Default)]
+pub struct PlatformSpecificHeadlessBuilderAttributes;
+
 pub struct HeadlessContext(i32);
 
 impl HeadlessContext {
     /// See the docs in the crate root file.
-    pub fn new(_: (u32, u32), _: &PixelFormatRequirements, _: &GlAttributes<&HeadlessContext>)
-            -> Result<HeadlessContext, CreationError> {
+    pub fn new(_: (u32, u32), _: &PixelFormatRequirements, _: &GlAttributes<&HeadlessContext>,
+               _: &PlatformSpecificHeadlessBuilderAttributes)
+               -> Result<HeadlessContext, CreationError>
+    {
         unimplemented!()
     }
 

--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -22,6 +22,9 @@ use api::x11::XConnection;
 use api::x11::XError;
 use api::x11::XNotSupported;
 
+#[derive(Default)]
+pub struct PlatformSpecificWindowBuilderAttributes;
+
 enum Backend {
     X(Arc<XConnection>),
     Wayland,
@@ -172,7 +175,8 @@ impl<'a> Iterator for WaitEventsIterator<'a> {
 impl Window {
     #[inline]
     pub fn new(window: &WindowAttributes, pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&Window>) -> Result<Window, CreationError>
+               opengl: &GlAttributes<&Window>, _: &PlatformSpecificWindowBuilderAttributes)
+               -> Result<Window, CreationError>
     {
         match *BACKEND {
             Backend::Wayland => {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -12,13 +12,19 @@ use api::osmesa::{self, OsMesaContext};
 
 pub use self::api_dispatch::{Window, WindowProxy, MonitorId, get_available_monitors, get_primary_monitor};
 pub use self::api_dispatch::{WaitEventsIterator, PollEventsIterator};
+pub use self::api_dispatch::PlatformSpecificWindowBuilderAttributes;
 mod api_dispatch;
+
+#[derive(Default)]
+pub struct PlatformSpecificHeadlessBuilderAttributes;
 
 pub struct HeadlessContext(OsMesaContext);
 
 impl HeadlessContext {
     pub fn new(dimensions: (u32, u32), pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&HeadlessContext>) -> Result<HeadlessContext, CreationError>
+               opengl: &GlAttributes<&HeadlessContext>,
+               _: &PlatformSpecificHeadlessBuilderAttributes)
+               -> Result<HeadlessContext, CreationError>
     {
         let opengl = opengl.clone().map_sharing(|c| &c.0);
 

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -51,6 +51,10 @@ lazy_static! {
     };
 }
 
+#[derive(Default)]
+pub struct PlatformSpecificWindowBuilderAttributes;
+#[derive(Default)]
+pub struct PlatformSpecificHeadlessBuilderAttributes;
 
 /// The Win32 implementation of the main `Window` object.
 pub struct Window(win32::Window);
@@ -59,7 +63,8 @@ impl Window {
     /// See the docs in the crate root file.
     #[inline]
     pub fn new(window: &WindowAttributes, pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&Window>) -> Result<Window, CreationError>
+               opengl: &GlAttributes<&Window>, _: &PlatformSpecificWindowBuilderAttributes)
+               -> Result<Window, CreationError>
     {
         win32::Window::new(window, pf_reqs, &opengl.clone().map_sharing(|w| &w.0),
                            EGL.as_ref().map(|w| &w.0)).map(|w| Window(w))
@@ -92,7 +97,9 @@ pub enum HeadlessContext {
 
 impl HeadlessContext {
     pub fn new(dimensions: (u32, u32), pf_reqs: &PixelFormatRequirements,
-               opengl: &GlAttributes<&HeadlessContext>) -> Result<HeadlessContext, CreationError>
+               opengl: &GlAttributes<&HeadlessContext>,
+               _: &PlatformSpecificHeadlessBuilderAttributes)
+               -> Result<HeadlessContext, CreationError>
     {
         // if EGL is available, we try using EGL first
         // if EGL returns an error, we try the hidden window method

--- a/src/window.rs
+++ b/src/window.rs
@@ -31,6 +31,9 @@ pub struct WindowBuilder<'a> {
 
     // Should be made public once it's stabilized.
     pf_reqs: PixelFormatRequirements,
+
+    /// Platform-specific configuration.
+    platform_specific: platform::PlatformSpecificWindowBuilderAttributes,
 }
 
 impl<'a> WindowBuilder<'a> {
@@ -41,6 +44,7 @@ impl<'a> WindowBuilder<'a> {
             pf_reqs: Default::default(),
             window: Default::default(),
             opengl: Default::default(),
+            platform_specific: Default::default(),
         }
     }
 
@@ -227,7 +231,7 @@ impl<'a> WindowBuilder<'a> {
         }
 
         // building
-        platform::Window::new(&self.window, &self.pf_reqs, &self.opengl)
+        platform::Window::new(&self.window, &self.pf_reqs, &self.opengl, &self.platform_specific)
                             .map(|w| Window { window: w })
     }
 


### PR DESCRIPTION
Motivations:
 - #688 
 - Add the possibility to set the parent window ID on Linux or to say whether we prefer X11 or Wayland.

How to use it:

```rust
#[cfg(windows)]
use glutin::os::windows::WindowBuilderExt;

let mut window_builder = glutin::WindowBuilder::new();
window_builder.set_icon_path("icon.ico");   // available through the `WindowBuilderExt` trait
let window = window_builder.build().unwrap();
```
