### PR TITLE
Fix double buffering on egl and restore default (fixing everything else)

### DIFF
--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -538,7 +538,7 @@ unsafe fn choose_fbconfig(egl: &ffi::egl::Egl, display: ffi::egl::types::EGLDisp
             out.push(stencil as c_int);
         }
 
-        if let Some(true) = reqs.double_buffer {
+        if let Some(false) = reqs.double_buffer {
             return Err(CreationError::NoAvailablePixelFormat);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ impl Default for PixelFormatRequirements {
             alpha_bits: Some(8),
             depth_bits: Some(24),
             stencil_bits: Some(8),
-            double_buffer: None,
+            double_buffer: Some(true),
             multisampling: None,
             stereoscopy: false,
             srgb: false,


### PR DESCRIPTION
Restore the default that was changed by https://github.com/tomaka/glutin/pull/690 (changing defaults isn't nice)

fix double buffer requirement check

double_buffering is forced on at line 603 and so this should fail if single buffer was requested