### PR TITLE
Adding os::macos for accessing the underlying NSWindow

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -690,7 +690,7 @@ impl Window {
 
     #[inline]
     pub fn platform_window(&self) -> *mut libc::c_void {
-        unimplemented!()
+        *self.window as *mut libc::c_void
     }
 
     #[inline]

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -1,0 +1,19 @@
+#![cfg(target_os = "macos")]
+
+use std::os::raw::c_void;
+use Window;
+
+/// Additional methods on `Window` that are specific to MacOS.
+pub trait WindowExt {
+    /// Returns a pointer to the cocoa `NSWindow` that is used by this window.
+    ///
+    /// The pointer will become invalid when the glutin `Window` is destroyed.
+    fn get_nswindow(&self) -> *mut c_void;
+}
+
+impl WindowExt for Window {
+    #[inline]
+    fn get_nswindow(&self) -> *mut c_void {
+        self.window.platform_window() as *mut c_void
+    }
+}

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! Contains the follow modules:
 //!
+//!  - `macos`
 //!  - `unix`
 //!  - `windows`
 //!
+pub mod macos;
 pub mod unix;
 pub mod windows;


### PR DESCRIPTION
Also implements platform_window() for cocoa.