### PR TITLE
Fix this_platform_is_not_supported on OpenBSD.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,10 @@ wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
 wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.3"
+
+[target.x86_64-unknown-openbsd.dependencies]
+osmesa-sys = "0.0.5"
+wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
+wayland-kbd = "0.3.3"
+wayland-window = "0.2.2"
+x11-dl = "~2.3"

--- a/build.rs
+++ b/build.rs
@@ -63,7 +63,7 @@ fn main() {
                                         "1.5", "core", &mut file).unwrap();
     }
 
-    if target.contains("linux") || target.contains("dragonfly") || target.contains("freebsd") {
+    if target.contains("linux") || target.contains("dragonfly") || target.contains("freebsd") || target.contains("openbsd") {
         let mut file = File::create(&dest.join("glx_bindings.rs")).unwrap();
         gl_generator::generate_bindings(gl_generator::StructGenerator,
                                         gl_generator::registry::Ns::Glx,

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 #![allow(unused_variables, dead_code)]
 
 use libc;

--- a/src/api/dlopen.rs
+++ b/src/api/dlopen.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 #![allow(dead_code)]
 
 use std::os::raw::{c_void, c_char, c_int};

--- a/src/api/egl/ffi.rs
+++ b/src/api/egl/ffi.rs
@@ -33,5 +33,5 @@ pub type EGLNativeWindowType = winapi::HWND;
 pub type EGLNativeWindowType = *const libc::c_void;
 #[cfg(target_os = "android")]
 pub type EGLNativeWindowType = *const libc::c_void;
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 pub type EGLNativeWindowType = *const libc::c_void;

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -1,5 +1,5 @@
 #![cfg(any(target_os = "windows", target_os = "linux", target_os = "android",
-           target_os = "dragonfly", target_os = "freebsd"))]
+           target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 #![allow(unused_variables)]
 
 use ContextError;

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
 use ContextError;
 use CreationError;

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
 extern crate osmesa_sys;
 

--- a/src/api/wayland/mod.rs
+++ b/src/api/wayland/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
 pub use self::monitor::{MonitorId, get_available_monitors, get_primary_monitor};
 pub use self::window::{PollEventsIterator, WaitEventsIterator, Window, WindowProxy};

--- a/src/api/x11/mod.rs
+++ b/src/api/x11/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
 pub use self::monitor::{MonitorId, get_available_monitors, get_primary_monitor};
 pub use self::window::{Window, XWindow, PollEventsIterator, WaitEventsIterator, Context, WindowProxy};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,9 @@ extern crate cocoa;
 extern crate core_foundation;
 #[cfg(target_os = "macos")]
 extern crate core_graphics;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 extern crate x11_dl;
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
 #[macro_use(wayland_env)]
 extern crate wayland_client;
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
 use libc;
 use Window;

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
 use Api;
 use ContextError;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -3,7 +3,7 @@ pub use self::platform::*;
 #[cfg(target_os = "windows")]
 #[path="windows/mod.rs"]
 mod platform;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 #[path="linux/mod.rs"]
 mod platform;
 #[cfg(target_os = "macos")]
@@ -21,5 +21,5 @@ mod platform;
 
 #[cfg(all(not(target_os = "ios"), not(target_os = "windows"), not(target_os = "linux"),
   not(target_os = "macos"), not(target_os = "android"), not(target_os = "dragonfly"),
-  not(target_os = "freebsd"), not(target_os = "emscripten")))]
+  not(target_os = "freebsd"), not(target_os = "openbsd"), not(target_os = "emscripten")))]
 use this_platform_is_not_supported;


### PR DESCRIPTION
I followed the steps of @mneumann.

Now runs on snapshot OpenBSD 5.9 with X11, rustc 1.6.0 and cargo 0.9.0 from https://github.com/jasperla/openbsd-wip.