### PR TITLE
Introduce unix::WindowBuilderExt::with_xlib_parent

### DIFF
--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -42,8 +42,13 @@ impl WindowExt for Window {
 
 /// Additional methods on `WindowBuilder` that are specific to Unix.
 pub trait WindowBuilderExt {
-
+    /// Sets the Xlib parent window.
+    fn with_xlib_parent(self, parent: Option<WindowId>) -> WindowBuilder<'a>;
 }
 
 impl<'a> WindowBuilderExt for WindowBuilder<'a> {
+    fn with_xlib_parent(mut self, parent: Option<WindowId>) -> WindowBuilder<'a> {
+        self.platform_specific.xlib_parent = parent;
+        self
+    }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -16,7 +16,9 @@ pub use self::api_dispatch::PlatformSpecificWindowBuilderAttributes;
 mod api_dispatch;
 
 #[derive(Default)]
-pub struct PlatformSpecificHeadlessBuilderAttributes;
+pub struct PlatformSpecificHeadlessBuilderAttributes {
+    pub xlib_parent: Option<WindowID>,
+}
 
 pub struct HeadlessContext(OsMesaContext);
 


### PR DESCRIPTION
Upstreamed from Servo's fork, fixes https://github.com/servo/glutin/issues/71.