### PR TITLE
Update objc dependency to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,24 +23,24 @@ khronos_api = "1.0"
 version = "0.1"
 
 [target.i386-apple-ios.dependencies]
-objc = "0.1.8"
+objc = "0.2"
 
 [target.x86_64-apple-ios.dependencies]
-objc = "0.1.8"
+objc = "0.2"
 
 [target.aarch64-apple-ios.dependencies]
-objc = "0.1.8"
+objc = "0.2"
 
 [target.armv7s-apple-ios.dependencies]
-objc = "0.1.8"
+objc = "0.2"
 
 [target.armv7-apple-ios.dependencies]
-objc = "0.1.8"
+objc = "0.2"
 
 [target.x86_64-apple-darwin.dependencies]
-objc = "0.1.8"
+objc = "0.2"
 cgl = "0.1"
-cocoa = "0.2.4"
+cocoa = "0.3"
 core-foundation = "0"
 core-graphics = "0.3"
 

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -79,11 +79,12 @@ struct WindowDelegate {
 impl WindowDelegate {
     /// Get the delegate class, initiailizing it neccessary
     fn class() -> *const Class {
+        use std::os::raw::c_void;
         use std::sync::{Once, ONCE_INIT};
 
         extern fn window_should_close(this: &Object, _: Sel, _: id) -> BOOL {
             unsafe {
-                let state: *mut libc::c_void = *this.get_ivar("glutinState");
+                let state: *mut c_void = *this.get_ivar("glutinState");
                 let state = state as *mut DelegateState;
                 (*state).pending_events.lock().unwrap().push_back(Closed);
             }
@@ -92,7 +93,7 @@ impl WindowDelegate {
 
         extern fn window_did_resize(this: &Object, _: Sel, _: id) {
             unsafe {
-                let state: *mut libc::c_void = *this.get_ivar("glutinState");
+                let state: *mut c_void = *this.get_ivar("glutinState");
                 let state = &mut *(state as *mut DelegateState);
 
                 let _: () = msg_send![*state.context, update];
@@ -111,7 +112,7 @@ impl WindowDelegate {
                 // TODO: center the cursor if the window had mouse grab when it
                 // lost focus
 
-                let state: *mut libc::c_void = *this.get_ivar("glutinState");
+                let state: *mut c_void = *this.get_ivar("glutinState");
                 let state = state as *mut DelegateState;
                 (*state).pending_events.lock().unwrap().push_back(Focused(true));
             }
@@ -119,7 +120,7 @@ impl WindowDelegate {
 
         extern fn window_did_resign_key(this: &Object, _: Sel, _: id) {
             unsafe {
-                let state: *mut libc::c_void = *this.get_ivar("glutinState");
+                let state: *mut c_void = *this.get_ivar("glutinState");
                 let state = state as *mut DelegateState;
                 (*state).pending_events.lock().unwrap().push_back(Focused(false));
             }
@@ -131,7 +132,7 @@ impl WindowDelegate {
         INIT.call_once(|| unsafe {
             // Create new NSWindowDelegate
             let superclass = Class::get("NSObject").unwrap();
-            let mut decl = ClassDecl::new(superclass, "GlutinWindowDelegate").unwrap();
+            let mut decl = ClassDecl::new("GlutinWindowDelegate", superclass).unwrap();
 
             // Add callback methods
             decl.add_method(sel!(windowShouldClose:),
@@ -145,7 +146,7 @@ impl WindowDelegate {
                 window_did_resign_key as extern fn(&Object, Sel, id));
 
             // Store internal state as user data
-            decl.add_ivar::<*mut libc::c_void>("glutinState");
+            decl.add_ivar::<*mut c_void>("glutinState");
 
             delegate_class = decl.register();
         });
@@ -162,7 +163,7 @@ impl WindowDelegate {
         unsafe {
             let delegate = IdRef::new(msg_send![WindowDelegate::class(), new]);
 
-            (&mut **delegate).set_ivar("glutinState", state_ptr as *mut libc::c_void);
+            (&mut **delegate).set_ivar("glutinState", state_ptr as *mut ::std::os::raw::c_void);
             let _: () = msg_send![*state.window, setDelegate:*delegate];
 
             WindowDelegate { state: state, _this: delegate }
@@ -673,8 +674,8 @@ impl Window {
         let sel = Sel::register(cursor_name);
         let cls = Class::get("NSCursor").unwrap();
         unsafe {
-            use objc::MessageArguments;
-            let cursor: id = ().send(cls as *const _ as id, sel);
+            use objc::Message;
+            let cursor: id = cls.send_message(sel, ()).unwrap();
             let _: () = msg_send![cursor, set];
         }
     }


### PR DESCRIPTION
I just published version 0.2 of the objc crate, changelog here: https://github.com/SSheldon/rust-objc/blob/master/CHANGELOG.md#020

Main differences are gnustep support, (optionally) more type checking, removed the libc dependency, and fixed a bug in the space reserved for ivars when declaring classes.

By removing the libc dependency, objc [can't break glutin anymore](https://github.com/SSheldon/rust-objc/commit/fbb62f89e77266500b08e7cc331926a67a7784d9#commitcomment-14262093) by having a mismatch between libc versions :) 

This requires servo/cocoa-rs#120 to be merged first, which also means the Travis checks will fail until then.

Testing: verified glutin still compiles and tests pass, verified the window example looks good.