### PR TITLE
Get cursor pos

### DIFF
--- a/examples/get_cursor_pos.rs
+++ b/examples/get_cursor_pos.rs
@@ -1,0 +1,20 @@
+extern crate glutin;
+
+fn main() {
+    let mut window = glutin::WindowBuilder::new().build().unwrap();
+    window.set_title("A fantastic window!");
+    let _ = unsafe { window.make_current() };
+
+    for event in window.wait_events() {
+        match event {
+            glutin::Event::KeyboardInput(_, _, _) => {
+                match window.get_cursor_position() {
+                    Ok((x, y)) => println!("Cursor pos: {}, {}", x, y),
+                    Err(())    => println!("Error retrieving cursor position."),
+                }
+            },
+            glutin::Event::Closed => break,
+            _ => ()
+        }
+    }
+}

--- a/examples/get_cursor_pos.rs
+++ b/examples/get_cursor_pos.rs
@@ -1,9 +1,8 @@
 extern crate glutin;
 
 fn main() {
-    let mut window = glutin::WindowBuilder::new().build().unwrap();
-    window.set_title("A fantastic window!");
-    let _ = unsafe { window.make_current() };
+    let window = glutin::WindowBuilder::new().build().unwrap();
+    window.set_title("Press any key to display cursor position");
 
     for event in window.wait_events() {
         match event {

--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -256,6 +256,11 @@ impl Window {
     pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
         unimplemented!();
     }
+
+    #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        unimplemented!();
+    }
 }
 
 unsafe impl Send for Window {}

--- a/src/api/caca/ffi.rs
+++ b/src/api/caca/ffi.rs
@@ -20,4 +20,6 @@ shared_library!(LibCaca, "libcaca.so.0",
                               bmask: libc::uint32_t, amask: libc::uint32_t) -> *mut caca_dither_t,
     pub fn caca_get_canvas_width(cv: *mut caca_canvas_t) -> libc::c_int,
     pub fn caca_get_canvas_height(cv: *mut caca_canvas_t) -> libc::c_int,
+    pub fn caca_wherex(cv: *const caca_canvas_t) -> libc::c_int,
+    pub fn caca_wherey(cv: *const caca_canvas_t) -> libc::c_int,
 );

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -244,7 +244,7 @@ impl Window {
         let canvas = (self.libcaca.caca_get_canvas)(self.display);
         let x = (self.libcaca.caca_wherex)(canvas);
         let y = (self.libcaca.caca_wherey)(canvas);
-        (x as i32, y as i32)
+        Ok((x as i32, y as i32))
     }
 }
 

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -241,7 +241,10 @@ impl Window {
 
     #[inline]
     pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
-        Err(())
+        let canvas = (self.libcaca.caca_get_canvas)(self.display);
+        let x = (self.libcaca.caca_wherex)(canvas);
+        let y = (self.libcaca.caca_wherey)(canvas);
+        (x as i32, y as i32)
     }
 }
 

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -238,6 +238,11 @@ impl Window {
     pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
         Ok(())
     }
+
+    #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        Err(())
+    }
 }
 
 impl GlContext for Window {

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -241,10 +241,12 @@ impl Window {
 
     #[inline]
     pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
-        let canvas = (self.libcaca.caca_get_canvas)(self.display);
-        let x = (self.libcaca.caca_wherex)(canvas);
-        let y = (self.libcaca.caca_wherey)(canvas);
-        Ok((x as i32, y as i32))
+        unsafe {
+            let canvas = (self.libcaca.caca_get_canvas)(self.display);
+            let x = (self.libcaca.caca_wherex)(canvas);
+            let y = (self.libcaca.caca_wherey)(canvas);
+            Ok((x as i32, y as i32))
+        }
     }
 }
 

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -727,11 +727,8 @@ impl Window {
     #[inline]
     pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
         unsafe {
-            // Very unsafe, but I think it's fine as mouseLocation doesn't touch the pointer.
-            // https://github.com/servo/cocoa-rs/blob/master/src/appkit.rs#L2070-L2072
-            // TODO: Check for errors.
-            let point = NSEvent::mouseLocation(ptr::null_mut() as id);
-            Ok(self.view.convertPoint_fromView_(point, ptr::null_mut() as id))
+            let point = self.window.mouseLocationOutsideOfEventStream();
+            Ok((point.x, point.y))
         }
     }
 }

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -27,7 +27,6 @@ use cocoa::foundation::{NSAutoreleasePool, NSDate, NSDefaultRunLoopMode, NSPoint
 use cocoa::appkit;
 use cocoa::appkit::*;
 use cocoa::appkit::NSEventSubtype::*;
-use cocoa::foundation::NSPoint;
 
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
@@ -728,7 +727,7 @@ impl Window {
     pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
         unsafe {
             let point = self.window.mouseLocationOutsideOfEventStream();
-            Ok((point.x, point.y))
+            Ok((point.x as i32, point.y as i32))
         }
     }
 }

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -27,6 +27,7 @@ use cocoa::foundation::{NSAutoreleasePool, NSDate, NSDefaultRunLoopMode, NSPoint
 use cocoa::appkit;
 use cocoa::appkit::*;
 use cocoa::appkit::NSEventSubtype::*;
+use cocoa::foundation::NSPoint;
 
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
@@ -41,6 +42,7 @@ use std::str::from_utf8;
 use std::sync::Mutex;
 use std::ascii::AsciiExt;
 use std::ops::Deref;
+use std::ptr;
 
 use events::ElementState::{Pressed, Released};
 use events::Event::{Awakened, MouseInput, MouseMoved, ReceivedCharacter, KeyboardInput};
@@ -720,6 +722,17 @@ impl Window {
         }
 
         Ok(())
+    }
+
+    #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        unsafe {
+            // Very unsafe, but I think it's fine as mouseLocation doesn't touch the pointer.
+            // https://github.com/servo/cocoa-rs/blob/master/src/appkit.rs#L2070-L2072
+            // TODO: Check for errors.
+            let point = NSEvent::mouseLocation(ptr::null_mut() as id);
+            Ok(self.view.convertPoint_fromView_(point, ptr::null_mut() as id))
+        }
     }
 }
 

--- a/src/api/emscripten/mod.rs
+++ b/src/api/emscripten/mod.rs
@@ -229,6 +229,11 @@ impl Window {
     pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
         Ok(())
     }
+
+    #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        Err(())
+    }
 }
 
 impl GlContext for Window {

--- a/src/api/ios/mod.rs
+++ b/src/api/ios/mod.rs
@@ -366,6 +366,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        unimplemented!();
+    }
+
+    #[inline]
     pub fn create_window_proxy(&self) -> WindowProxy {
         WindowProxy
     }

--- a/src/api/wayland/window.rs
+++ b/src/api/wayland/window.rs
@@ -320,6 +320,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        // TODO: 
+        Err(())
+    }
+
+    #[inline]
     pub fn platform_display(&self) -> *mut libc::c_void {
         unimplemented!()
     }

--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -367,6 +367,21 @@ impl Window {
 
         Ok(())
     }
+
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        let mut point: winapi::POINT = unsafe { mem::uninitialized() };
+
+        unsafe {
+            if user32::GetCursorPos(&mut point) == 0 {
+                return Err(());
+            }
+
+            if user32::ScreenToClient(self.window.0, &mut point) == 0 {
+                return Err(());
+            }
+        }
+        Ok((point.x, point.y))
+    }
 }
 
 impl GlContext for Window {

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -1026,6 +1026,21 @@ impl Window {
             self.x.display.check_errors().map_err(|_| ())
         }
     }
+
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        unsafe {
+            let root_return: ffi::Window  = mem::uninitialized();
+            let child_return: ffi::Window = mem::uninitialized();
+            let root_x_return: libc::int  = mem::uninitialized();
+            let root_y_return: libc::int  = mem::uninitialized();
+            let win_x_return: libc::int   = mem::uninitialized();
+            let win_y_return: libc::int   = mem::uninitialized();
+            let mask_return: libc::uint   = mem::uninitialized();
+
+            self.x.display.xlib.XQueryPointer(self.x.display.display, self.x.window, &mut root_return, &mut child_return, &mut root_x_return, &mut root_y_return, &mut win_x_return, &mut win_y_return, &mut mask_return);
+            self.x.display.check_errors().map(|_| (win_x_return as i32, win_y_return as i32)).map_err(|_| ())
+        }
+    }
 }
 
 impl GlContext for Window {

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -1029,15 +1029,15 @@ impl Window {
 
     pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
         unsafe {
-            let root_return: ffi::Window  = mem::uninitialized();
-            let child_return: ffi::Window = mem::uninitialized();
-            let root_x_return: libc::int  = mem::uninitialized();
-            let root_y_return: libc::int  = mem::uninitialized();
-            let win_x_return: libc::int   = mem::uninitialized();
-            let win_y_return: libc::int   = mem::uninitialized();
-            let mask_return: libc::uint   = mem::uninitialized();
+            let root_return  : ffi::Window = mem::uninitialized();
+            let child_return : ffi::Window = mem::uninitialized();
+            let root_x_return: libc::c_int = mem::uninitialized();
+            let root_y_return: libc::c_int = mem::uninitialized();
+            let win_x_return : libc::c_int = mem::uninitialized();
+            let win_y_return : libc::c_int = mem::uninitialized();
+            let mask_return  : libc::c_uint = mem::uninitialized();
 
-            self.x.display.xlib.XQueryPointer(self.x.display.display, self.x.window, &mut root_return, &mut child_return, &mut root_x_return, &mut root_y_return, &mut win_x_return, &mut win_y_return, &mut mask_return);
+            (self.x.display.xlib.XQueryPointer)(self.x.display.display, self.x.window, &mut root_return, &mut child_return, &mut root_x_return, &mut root_y_return, &mut win_x_return, &mut win_y_return, &mut mask_return);
             self.x.display.check_errors().map(|_| (win_x_return as i32, win_y_return as i32)).map_err(|_| ())
         }
     }

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -1029,13 +1029,13 @@ impl Window {
 
     pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
         unsafe {
-            let root_return  : ffi::Window = mem::uninitialized();
-            let child_return : ffi::Window = mem::uninitialized();
-            let root_x_return: libc::c_int = mem::uninitialized();
-            let root_y_return: libc::c_int = mem::uninitialized();
-            let win_x_return : libc::c_int = mem::uninitialized();
-            let win_y_return : libc::c_int = mem::uninitialized();
-            let mask_return  : libc::c_uint = mem::uninitialized();
+            let mut root_return  : ffi::Window = mem::uninitialized();
+            let mut child_return : ffi::Window = mem::uninitialized();
+            let mut root_x_return: libc::c_int = mem::uninitialized();
+            let mut root_y_return: libc::c_int = mem::uninitialized();
+            let mut win_x_return : libc::c_int = mem::uninitialized();
+            let mut win_y_return : libc::c_int = mem::uninitialized();
+            let mut mask_return  : libc::c_uint = mem::uninitialized();
 
             (self.x.display.xlib.XQueryPointer)(self.x.display.display, self.x.window, &mut root_return, &mut child_return, &mut root_x_return, &mut root_y_return, &mut win_x_return, &mut win_y_return, &mut mask_return);
             self.x.display.check_errors().map(|_| (win_x_return as i32, win_y_return as i32)).map_err(|_| ())

--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -330,6 +330,14 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        match self {
+            &Window::X(ref w) => w.get_cursor_position(),
+            &Window::Wayland(ref w) => w.get_cursor_position()
+        }
+    }
+
+    #[inline]
     pub fn platform_display(&self) -> *mut libc::c_void {
         match self {
             &Window::X(ref w) => w.platform_display(),

--- a/src/window.rs
+++ b/src/window.rs
@@ -502,6 +502,12 @@ impl Window {
     pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
         self.window.set_cursor_position(x, y)
     }
+    
+    /// Gets the position of the cursor in window coordinates.
+    #[inline]
+    pub fn get_cursor_position(&self) -> Result<(i32, i32), ()> {
+        self.window.get_cursor_position()
+    }
 
     /// Sets how glutin handles the cursor. See the documentation of `CursorState` for details.
     ///


### PR DESCRIPTION
This PR adds a new function, `get_cursor_pos` to `Window`. It is meant to call the underlying system and request the cursor position relative to the window origin. I made this because currently, on Windows at least, it is impossible through glutin to get the current cursor position.

I tried to implement all systems, however I cannot test if this works everywhere, only on Windows.
