### PR TITLE
Generalize WindowBuilder::with_title

### DIFF
--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -32,7 +32,7 @@ fn main() {
     };
 
     let window = glutin::WindowBuilder::new()
-        .with_title("Hello world!".to_string())
+        .with_title("Hello world!")
         .with_fullscreen(monitor)
         .build()
         .unwrap();

--- a/src/window.rs
+++ b/src/window.rs
@@ -63,8 +63,8 @@ impl<'a> WindowBuilder<'a> {
 
     /// Requests a specific title for the window.
     #[inline]
-    pub fn with_title(mut self, title: String) -> WindowBuilder<'a> {
-        self.window.title = title;
+    pub fn with_title<T: Into<String>>(mut self, title: T) -> WindowBuilder<'a> {
+        self.window.title = title.into();
         self
     }
 


### PR DESCRIPTION
The pull request makes the usage of `with_title` a bit more convenient for static titles.

Regards,
Ivan