### PR TITLE
Remove unused private fields from cocoa HeadlessContext struct.

### DIFF
--- a/src/api/cocoa/headless.rs
+++ b/src/api/cocoa/headless.rs
@@ -17,8 +17,6 @@ use api::cocoa::helpers;
 pub struct PlatformSpecificHeadlessBuilderAttributes;
 
 pub struct HeadlessContext {
-    width: u32,
-    height: u32,
     context: id,
 }
 
@@ -44,8 +42,6 @@ impl HeadlessContext {
         };
 
         let headless = HeadlessContext {
-            width: width,
-            height: height,
             context: context,
         };
 


### PR DESCRIPTION
This was emitting a warning on OS X.