### PR TITLE
Rather than returning `Event::Awakened` for every unknown event type, only return one when a `NSApplicationActivatedEventType` is received (this is the event produced by `WindowProxy::wakeup_event_loop`)

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -917,6 +917,12 @@ unsafe fn NSEventToEvent(window: &Window, nsevent: id) -> Option<Event> {
         appkit::NSEventTypePressure => {
             Some(Event::TouchpadPressure(nsevent.pressure(), nsevent.stage()))
         },
-        _  => { None },
+        appkit::NSApplicationDefined => match nsevent.subtype() {
+            appkit::NSEventSubtype::NSApplicationActivatedEventType => {
+                Some(Event::Awakened)
+            },
+            _ => None,
+        },
+        _ => None,
     }
 }


### PR DESCRIPTION
The original behaviour returns an `Event::Awakened` for every unknown event type (see [here](https://github.com/tomaka/glutin/blob/0c4cf714a103bf2fa67c77f8f55111ae78bc0e6d/src/api/cocoa/mod.rs#L266-L267)). This PR changes the behaviour so that rather than returning `Event::Awakened` if `NSEventToEvent` returns `None`, we instead `loop` until `NSEventToEvent` returns `Some(Event)`.

The `wait_events` docs mention that the `Iterator` should never return `None`, so it's possible that the returning of `Event::Awakened` might have originally been a hack to avoid returning `None` when `NSEventToEvent` returns `None`.

This may be a **breaking change** for downstream programs that depend on receiving `Awakened` on OS X for some reason (though they probably shouldn't, as the current behaviour does not seem to reflect the `Awakened` docs at all). _Edit: This PR still returns `Awakened`, but only when the event loop is actually awakened_.

I've tested the changes with the window.rs example (which uses the `WaitEventsIterator`) and it seems to handle all the events I can throw at it from my macbook pro without issues, still sitting between 0.0 - 0.1% cpu when idle. The only difference being it no longer returns seemingly random `Awakened` events. I'm on OS X 10.10.5.

@paulrouget sorry to bug you! I noticed you occasionally review cocoa-related PRs - would you mind reviewing this?
