### PR TITLE
cocoa - Change `IdRef` `Drop` implementation to use `autorelease` instead of `release`. Fixes Yosemite segfault that occurs upon `Closed`.

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -799,7 +799,7 @@ impl IdRef {
 impl Drop for IdRef {
     fn drop(&mut self) {
         if self.0 != nil {
-            let _: () = unsafe { msg_send![self.0, release] };
+            let _: () = unsafe { msg_send![self.0, autorelease] };
         }
     }
 }


### PR DESCRIPTION
This still relinquishes ownership over the object when `IdRef` is dropped, however leaves the actual releasing of the object until the enclosing autorelease pool is released (which is the end of main if none are explicitly instantiated any higher in the stack). All of the objects wrapped by `IdRef` within our cocoa module exist for the lifetime of the `Window` anyway, so the difference between `release` and `autorelease` should be negligible.

This fixes the segfault that occurs when closing the window on OS X Yosemite (see #778). I've tested this in the `window.rs` example as well as a downstream conrod example and both no longer crash following the `Closed` event.

@fkaa @pcwalton I'm still very new to obj-c, would appreciate your thoughts