### PR TITLE
cocoa - Ensure the window does not set itself to `autorelease` upon closing as we release it manually via IdRef's drop method.

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -435,6 +435,7 @@ impl Window {
             ));
             window.non_nil().map(|window| {
                 let title = IdRef::new(NSString::alloc(nil).init_str(&attrs.title));
+                window.setReleasedWhenClosed_(NO);
                 window.setTitle_(*title);
                 window.setAcceptsMouseMovedEvents_(YES);
 


### PR DESCRIPTION
This is a better alternative to #795 discovered by @SSheldon that fixes the segfault discussed at #778.

Tested on OS X 10.10.5.