### PR TITLE
x11: handle X11's multi-key, a.k.a compose key.

### DIFF
--- a/src/api/x11/events.rs
+++ b/src/api/x11/events.rs
@@ -14,7 +14,7 @@ pub fn keycode_to_element(scancode: libc::c_uint) -> Option<VirtualKeyCode> {
         //ffi::XK_Sys_Req => events::VirtualKeyCode::Sys_req,
         ffi::XK_Escape => events::VirtualKeyCode::Escape,
         ffi::XK_Delete => events::VirtualKeyCode::Delete,
-        //ffi::XK_Multi_key => events::VirtualKeyCode::Multi_key,
+        ffi::XK_Multi_key => events::VirtualKeyCode::Compose,
         //ffi::XK_Kanji => events::VirtualKeyCode::Kanji,
         //ffi::XK_Muhenkan => events::VirtualKeyCode::Muhenkan,
         //ffi::XK_Henkan_Mode => events::VirtualKeyCode::Henkan_mode,

--- a/src/events.rs
+++ b/src/events.rs
@@ -220,6 +220,9 @@ pub enum VirtualKeyCode {
     /// The space bar.
     Space,
 
+    /// The "Compose" key on Linux.
+    Compose,
+
     Numlock,
     Numpad0,
     Numpad1,


### PR DESCRIPTION
This is needed for servo to land non-qwerty keyboard support.

r? @tomaka 