### PR TITLE
Add event `HasMouse(bool)` for mouse entering/leaving window

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -833,7 +833,8 @@ unsafe fn NSEventToEvent(window: &Window, nsevent: id) -> Option<Event> {
         appkit::NSLeftMouseUp           => { Some(Event::MouseInput(ElementState::Released, MouseButton::Left)) },
         appkit::NSRightMouseDown        => { Some(Event::MouseInput(ElementState::Pressed, MouseButton::Right)) },
         appkit::NSRightMouseUp          => { Some(Event::MouseInput(ElementState::Released, MouseButton::Right)) },
-        appkit::NSMouseExited           => { Some(Event::MouseLeft) }
+        appkit::NSMouseEntered           => { Some(Event::HasMouse(true)) }
+        appkit::NSMouseExited           => { Some(Event::HasMouse(false)) }
         appkit::NSMouseMoved            |
         appkit::NSLeftMouseDragged      |
         appkit::NSOtherMouseDragged     |

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -833,6 +833,7 @@ unsafe fn NSEventToEvent(window: &Window, nsevent: id) -> Option<Event> {
         appkit::NSLeftMouseUp           => { Some(Event::MouseInput(ElementState::Released, MouseButton::Left)) },
         appkit::NSRightMouseDown        => { Some(Event::MouseInput(ElementState::Pressed, MouseButton::Right)) },
         appkit::NSRightMouseUp          => { Some(Event::MouseInput(ElementState::Released, MouseButton::Right)) },
+        appkit::NSMouseExited           => { Some(Event::MouseLeft) }
         appkit::NSMouseMoved            |
         appkit::NSLeftMouseDragged      |
         appkit::NSOtherMouseDragged     |

--- a/src/api/wayland/events.rs
+++ b/src/api/wayland/events.rs
@@ -57,10 +57,10 @@ pub fn translate_event(
                     None
                 }
             }
-            WlPointerEvent::Leave(_, _) => {
+            WlPointerEvent::Leave(_, surface) => {
                 focuses.pointer_on = None;
                 focuses.pointer_at = None;
-                None
+                Some((GlutinEvent::MouseLeft, surface))
             }
             WlPointerEvent::Motion(_, x, y) => {
                 if let Some(surface) = focuses.pointer_on {

--- a/src/api/wayland/events.rs
+++ b/src/api/wayland/events.rs
@@ -52,7 +52,8 @@ pub fn translate_event(
                 if known_surfaces.contains(&surface) {
                     focuses.pointer_on = Some(surface);
                     focuses.pointer_at = Some((x, y));
-                    Some((GlutinEvent::MouseMoved(x as i32, y as i32), surface))
+                    // FIXME: Also trigger MouseMoved with x and y?
+                    Some((GlutinEvent::HasMouse(true), surface))
                 } else {
                     None
                 }
@@ -60,7 +61,7 @@ pub fn translate_event(
             WlPointerEvent::Leave(_, surface) => {
                 focuses.pointer_on = None;
                 focuses.pointer_at = None;
-                Some((GlutinEvent::MouseLeft, surface))
+                Some((GlutinEvent::HasMouse(false), surface))
             }
             WlPointerEvent::Motion(_, x, y) => {
                 if let Some(surface) = focuses.pointer_on {

--- a/src/api/win32/callback.rs
+++ b/src/api/win32/callback.rs
@@ -131,6 +131,14 @@ pub unsafe extern "system" fn callback(window: winapi::HWND, msg: winapi::UINT,
             0
         },
 
+        winapi::WM_MOUSELEAVE => {
+            use events::Event::MouseLeft;
+
+            send_event(window, MouseLeft);
+
+            0
+        },
+
         winapi::WM_MOUSEWHEEL => {
             use events::Event::MouseWheel;
             use events::MouseScrollDelta::LineDelta;

--- a/src/api/win32/init.rs
+++ b/src/api/win32/init.rs
@@ -217,6 +217,7 @@ unsafe fn init(title: Vec<u16>, window: &WindowAttributes, pf_reqs: &PixelFormat
 
     // Creating a mutex to track the current window state
     let window_state = Arc::new(Mutex::new(WindowState {
+        has_cursor: false,
         cursor: winapi::IDC_ARROW, // use arrow by default
         cursor_state: CursorState::Normal,
         attributes: window.clone()

--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -48,6 +48,7 @@ pub type Cursor = *const winapi::wchar_t;
 /// Contains information about states and the window for the callback.
 #[derive(Clone)]
 pub struct WindowState {
+    pub has_cursor: bool,
     pub cursor: Cursor,
     pub cursor_state: CursorState,
     pub attributes: WindowAttributes

--- a/src/api/x11/input.rs
+++ b/src/api/x11/input.rs
@@ -170,7 +170,7 @@ impl XInputEventHandler {
     }
 
     pub fn translate_event(&mut self, cookie: &ffi::XGenericEventCookie) -> Option<Event> {
-        use events::Event::{Focused, MouseInput, MouseMoved, MouseWheel};
+        use events::Event::{Focused, MouseInput, MouseLeft, MouseMoved, MouseWheel};
         use events::ElementState::{Pressed, Released};
         use events::MouseButton::{Left, Right, Middle};
         use events::MouseScrollDelta::LineDelta;
@@ -256,7 +256,7 @@ impl XInputEventHandler {
                 self.current_state.axis_values.clear();
                 None
             },
-            ffi::XI_Leave => None,
+            ffi::XI_Leave => Some(MouseLeft),
             ffi::XI_FocusIn => Some(Focused(true)),
             ffi::XI_FocusOut => Some(Focused(false)),
             ffi::XI_TouchBegin | ffi::XI_TouchUpdate | ffi::XI_TouchEnd => {

--- a/src/api/x11/input.rs
+++ b/src/api/x11/input.rs
@@ -170,7 +170,7 @@ impl XInputEventHandler {
     }
 
     pub fn translate_event(&mut self, cookie: &ffi::XGenericEventCookie) -> Option<Event> {
-        use events::Event::{Focused, MouseInput, MouseLeft, MouseMoved, MouseWheel};
+        use events::Event::{Focused, MouseInput, HasMouse, MouseMoved, MouseWheel};
         use events::ElementState::{Pressed, Released};
         use events::MouseButton::{Left, Right, Middle};
         use events::MouseScrollDelta::LineDelta;
@@ -254,9 +254,9 @@ impl XInputEventHandler {
                 // our window however, so clear the previous axis state whenever
                 // the cursor re-enters the window
                 self.current_state.axis_values.clear();
-                None
+                Some(HasMouse(true))
             },
-            ffi::XI_Leave => Some(MouseLeft),
+            ffi::XI_Leave => Some(HasMouse(false)),
             ffi::XI_FocusIn => Some(Focused(true)),
             ffi::XI_FocusOut => Some(Focused(false)),
             ffi::XI_TouchBegin | ffi::XI_TouchUpdate | ffi::XI_TouchEnd => {

--- a/src/events.rs
+++ b/src/events.rs
@@ -30,6 +30,11 @@ pub enum Event {
     /// The parameter are the (x,y) coords in pixels relative to the top-left corner of the window.
     MouseMoved(i32, i32),
 
+    /// The cursor has the window.
+    ///
+    /// The `MouseMoved` event implies the cursor has re-entered the window.
+    MouseLeft,
+
     /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel(MouseScrollDelta, TouchPhase),
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -30,10 +30,10 @@ pub enum Event {
     /// The parameter are the (x,y) coords in pixels relative to the top-left corner of the window.
     MouseMoved(i32, i32),
 
-    /// The cursor has the window.
+    /// The cursor has entered or left the window.
     ///
-    /// The `MouseMoved` event implies the cursor has re-entered the window.
-    MouseLeft,
+    /// The parameter is true if the cursor entered, and false if it left.
+    HasMouse(bool),
 
     /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel(MouseScrollDelta, TouchPhase),


### PR DESCRIPTION
This change adds a new event, `HasMouse(bool)`, and implements it for all platforms with mouse support (Windows, Cocoa, X11, and Wayland).
## Notes
- The event name is open to bikeshedding.
- I only tested this by making sure it builds successfully on Windows and Linux, so Cocoa is currently untested (but it's a _very_ minor change there).
- I'm unsure how acquiring the mutex on every mouse movement will perform on Windows, but I couldn't think of a better way to track whether the mouse was in the window...
## Other options

I considered implementing two separate events, `MouseLeft` and `MouseEntered(i32, i32)`, to better represent the mouse entering the window. I'm not sure if X11 and Cocoa support this; if we can confirm that they do, we can reconsider.

Ultimately, I want to get the [`Cursor(bool)` event](http://docs.piston.rs/piston/input/enum.Input.html) working on Piston's glutin back-end, which was another reason for implementing `HasMouse` with just a `bool`.
