### PR TITLE
Remove android_start! macro

### DIFF
--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,15 +1,8 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate glutin;
 
 use glutin::{Event, ElementState, MouseCursor};
 
 mod support;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     let window = glutin::WindowBuilder::new().build().unwrap();

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,15 +1,8 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate glutin;
 
 use std::io::{self, Write};
 
 mod support;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     // enumerating monitors

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -1,15 +1,8 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate glutin;
 
 use glutin::{Event, ElementState};
 
 mod support;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     let window = glutin::WindowBuilder::new().build().unwrap();

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,15 +1,8 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate glutin;
 
 use std::thread;
 
 mod support;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn main() {
     let window1 = glutin::WindowBuilder::new().build().unwrap();

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,13 +1,6 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate glutin;
 
 mod support;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn resize_callback(width: u32, height: u32) {
     println!("Window resized to {}x{}", width, height);

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,13 +1,6 @@
-#[cfg(target_os = "android")]
-#[macro_use]
-extern crate android_glue;
-
 extern crate glutin;
 
 mod support;
-
-#[cfg(target_os = "android")]
-android_start!(main);
 
 fn resize_callback(width: u32, height: u32) {
     println!("Window resized to {}x{}", width, height);


### PR DESCRIPTION
It was a requirement with android-rs-glue 0.1. With android-rs-glue 0.2 this macro call is no longer needed.