### PR TITLE
Integrate with `winit'

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -112,7 +112,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn winit_window(self) -> winit::Window {
+    pub fn to_winit_window(self) -> winit::Window {
         self.winit_window
     }
 

--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -112,13 +112,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn into_winit_window(self) -> winit::Window {
-        self.winit_window
-    }
-
-    #[inline]
     pub fn as_winit_window(&self) -> &winit::Window {
         &self.winit_window
+    }
+ 
+    #[inline]
+    pub fn as_winit_window_mut(&mut self) -> &mut winit::Window {
+        &mut self.winit_window
     }
 
     pub unsafe fn platform_window(&self) -> *mut libc::c_void {

--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -112,8 +112,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn to_winit_window(self) -> winit::Window {
+    pub fn into_winit_window(self) -> winit::Window {
         self.winit_window
+    }
+
+    #[inline]
+    pub fn as_winit_window(&self) -> &winit::Window {
+        &self.winit_window
     }
 
     pub unsafe fn platform_window(&self) -> *mut libc::c_void {

--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -172,6 +172,16 @@ impl Window {
         self.winit_window.platform_window()
     }
 
+    #[inline]
+    pub fn into_winit_window(self) -> winit::Window {
+        self.winit_window
+    }
+
+    #[inline]
+    pub fn as_winit_window(&self) -> &winit::Window {
+        &self.winit_window
+    }
+
     pub fn create_window_proxy(&self) -> winit::WindowProxy {
         self.winit_window.create_window_proxy()
     }

--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -178,10 +178,9 @@ impl Window {
     }
 
     #[inline]
-    pub fn as_winit_window(&mut self) -> &mut winit::Window {
+    pub fn as_winit_window_mut(&mut self) -> &mut winit::Window {
         &mut self.winit_window
     }
-    
 
     pub fn create_window_proxy(&self) -> winit::WindowProxy {
         self.winit_window.create_window_proxy()

--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -173,14 +173,15 @@ impl Window {
     }
 
     #[inline]
-    pub fn into_winit_window(self) -> winit::Window {
-        self.winit_window
-    }
-
-    #[inline]
     pub fn as_winit_window(&self) -> &winit::Window {
         &self.winit_window
     }
+
+    #[inline]
+    pub fn as_winit_window(&mut self) -> &mut winit::Window {
+        &mut self.winit_window
+    }
+    
 
     pub fn create_window_proxy(&self) -> winit::WindowProxy {
         self.winit_window.create_window_proxy()

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -156,7 +156,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn winit_window(self) -> winit::Window {
+    pub fn to_winit_window(self) -> winit::Window {
         self.winit_window
     }
 

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -156,8 +156,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn to_winit_window(self) -> winit::Window {
+    pub fn into_winit_window(self) -> winit::Window {
         self.winit_window
+    }
+
+    #[inline]
+    pub fn as_winit_window(&self) -> &winit::Window {
+        &self.winit_window
     }
 
     pub fn show(&self) {

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -156,13 +156,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn into_winit_window(self) -> winit::Window {
-        self.winit_window
+    pub fn as_winit_window(&self) -> &winit::Window {
+        &self.winit_window
     }
 
     #[inline]
-    pub fn as_winit_window(&self) -> &winit::Window {
-        &self.winit_window
+    pub fn as_winit_window_mut(&mut self) -> &mut winit::Window {
+        &mut self.winit_window
     }
 
     pub fn show(&self) {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -38,13 +38,12 @@ enum Context {
 
 impl Window {
     /// See the docs in the crate root file.
-    pub fn new(
-        _: &WindowAttributes,
-        pf_reqs: &PixelFormatRequirements,
-        opengl: &GlAttributes<&Window>,
-        egl: Option<&Egl>,
-        winit_builder: winit::WindowBuilder,
-    ) -> Result<Window, CreationError> {
+    pub fn new(_: &WindowAttributes,
+               pf_reqs: &PixelFormatRequirements,
+               opengl: &GlAttributes<&Window>,
+               egl: Option<&Egl>,
+               winit_builder: winit::WindowBuilder)
+               -> Result<Window, CreationError> {
         let winit_window = winit_builder.build().unwrap();
         let opengl = opengl.clone().map_sharing(|sharing| {
             match sharing.context {
@@ -57,25 +56,23 @@ impl Window {
             match opengl.version {
                 GlRequest::Specific(Api::OpenGlEs, (_major, _minor)) => {
                     if let Some(egl) = egl {
-                        if let Ok(c) = EglContext::new(egl.clone(), &pf_reqs, &opengl.clone().map_sharing(|_| unimplemented!()),
-                                                       egl::NativeDisplay::Other(Some(ptr::null())))
-                                                                     .and_then(|p| p.finish(w))
-                        {
+                        if let Ok(c) =
+                               EglContext::new(egl.clone(),
+                                               &pf_reqs,
+                                               &opengl.clone().map_sharing(|_| unimplemented!()),
+                                               egl::NativeDisplay::Other(Some(ptr::null())))
+                            .and_then(|p| p.finish(w)) {
                             Context::Egl(c)
                         } else {
-                            try!(WglContext::new(&pf_reqs, &opengl, w)
-                                                .map(Context::Wgl))
+                            try!(WglContext::new(&pf_reqs, &opengl, w).map(Context::Wgl))
                         }
 
                     } else {
                         // falling back to WGL, which is always available
-                        try!(WglContext::new(&pf_reqs, &opengl, w)
-                                            .map(Context::Wgl))
+                        try!(WglContext::new(&pf_reqs, &opengl, w).map(Context::Wgl))
                     }
-                },
-                _ => {
-                    try!(WglContext::new(&pf_reqs, &opengl, w).map(Context::Wgl))
                 }
+                _ => try!(WglContext::new(&pf_reqs, &opengl, w).map(Context::Wgl)),
             }
         };
         Ok(Window {
@@ -86,6 +83,11 @@ impl Window {
 
     pub fn set_title(&self, title: &str) {
         self.winit_window.set_title(title)
+    }
+
+    #[inline]
+    pub fn winit_window(self) -> winit::Window {
+        self.winit_window
     }
 
     pub fn show(&self) {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -86,13 +86,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn into_winit_window(self) -> winit::Window {
-        self.winit_window
+    pub fn as_winit_window(&self) -> &winit::Window {
+        &self.winit_window
     }
 
     #[inline]
-    pub fn as_winit_window(&self) -> &winit::Window {
-        &self.winit_window
+    pub fn as_winit_window_mut(&mut self) -> &mut winit::Window {
+        &mut self.winit_window
     }
 
     pub fn show(&self) {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -86,7 +86,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn winit_window(self) -> winit::Window {
+    pub fn to_winit_window(self) -> winit::Window {
         self.winit_window
     }
 

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -86,8 +86,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn to_winit_window(self) -> winit::Window {
+    pub fn into_winit_window(self) -> winit::Window {
         self.winit_window
+    }
+
+    #[inline]
+    pub fn as_winit_window(&self) -> &winit::Window {
+        &self.winit_window
     }
 
     pub fn show(&self) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,9 +12,9 @@ use Window;
 use WindowBuilder;
 
 pub use winit::WindowProxy;
-pub use winit::{AvailableMonitorsIter};
+pub use winit::AvailableMonitorsIter;
 pub use winit::{get_primary_monitor, get_available_monitors};
-pub use winit::{MonitorId};
+pub use winit::MonitorId;
 
 use libc;
 use platform;
@@ -33,6 +33,18 @@ impl<'a> WindowBuilder<'a> {
         }
     }
 
+    /// Initializes a new glutin `WindowBuilder` with the specified
+    /// winit `WindowBuilder` and default values for the other
+    /// parameters.
+    #[inline]
+    pub fn from_winit_builder(winit_builder: winit::WindowBuilder) -> WindowBuilder<'a> {
+        WindowBuilder {
+            pf_reqs: Default::default(),
+            winit_builder: winit_builder,
+            opengl: Default::default(),
+        }
+    }
+
     /// Requests the window to be of specific dimensions.
     ///
     /// Width and height are in pixels.
@@ -41,7 +53,7 @@ impl<'a> WindowBuilder<'a> {
         self.winit_builder = self.winit_builder.with_dimensions(width, height);
         self
     }
-    
+
     /// Sets a minimum dimension size for the window
     ///
     /// Width and height are in pixels.
@@ -209,14 +221,12 @@ impl<'a> WindowBuilder<'a> {
     /// Error should be very rare and only occur in case of permission denied, incompatible system,
     /// out of memory, etc.
     pub fn build(self) -> Result<Window, CreationError> {
-        let w = try!(platform::Window::new(
-            &Default::default(),
-            &self.pf_reqs,
-            &self.opengl,
-            &Default::default(),
-            self.winit_builder,
-        ));
-        Result::Ok(Window{window: w})
+        let w = try!(platform::Window::new(&Default::default(),
+                                           &self.pf_reqs,
+                                           &self.opengl,
+                                           &Default::default(),
+                                           self.winit_builder));
+        Result::Ok(Window { window: w })
     }
 
     /// Builds the window.
@@ -351,7 +361,7 @@ impl Window {
     pub fn get_inner_size(&self) -> Option<(u32, u32)> {
         self.window.get_inner_size()
     }
-    
+
     /// Returns the size in points of the client area of the window.
     ///
     /// The client area is the content of the window, excluding the title bar and borders.

--- a/src/window.rs
+++ b/src/window.rs
@@ -474,21 +474,20 @@ impl Window {
         self.window.platform_window()
     }
 
-    /// Converts the window into a winit::Window.
-    /// This is typically only required when integrating with
-    /// other libraries that need this information.
-    #[inline]
-    pub fn into_winit_window(self) -> winit::Window {
-        unimplemented!()
-        // self.window.into_winit_window() 
-    }
-
     /// Borrows the winit::Window inside this window.
     /// This is typically only required when integrating with
     /// other libraries that need this information.
     #[inline]
     pub fn as_winit_window(&self) -> &winit::Window {
        self.window.as_winit_window()
+    }
+
+    /// Mutably borrows the winit::Window inside this window.
+    /// This is typically only required when integrating with
+    /// other libraries that need this information.
+    #[inline]
+    pub fn as_winit_window_mut(&mut self) -> &mut winit::Window {
+       self.window.as_winit_window_mut()
     }
 
     /// Returns the API that is currently provided by this window.

--- a/src/window.rs
+++ b/src/window.rs
@@ -474,6 +474,23 @@ impl Window {
         self.window.platform_window()
     }
 
+    /// Converts the window into a winit::Window.
+    /// This is typically only required when integrating with
+    /// other libraries that need this information.
+    #[inline]
+    pub fn into_winit_window(self) -> winit::Window {
+        unimplemented!()
+        // self.window.into_winit_window() 
+    }
+
+    /// Borrows the winit::Window inside this window.
+    /// This is typically only required when integrating with
+    /// other libraries that need this information.
+    #[inline]
+    pub fn as_winit_window(&self) -> &winit::Window {
+       self.window.as_winit_window()
+    }
+
     /// Returns the API that is currently provided by this window.
     ///
     /// - On Windows and OS/X, this always returns `OpenGl`.


### PR DESCRIPTION
This is an attempt at solving issue #839. 

So far, I have added a 'constructor' method on glutin::WindowBuilder that takes in a winit::WindowBuilder.

I also have put methods on the Window structs for Windows, MacOS, and Android to convert a Window into a winit::Window. I am unsure how to achieve this on Linux, as the Linux platform code does not appear to keep a winit::Window inside its Window struct.

Another thing that needs to be taken into consideration is that currently the methods to get the winit::Window from the platform Window consume the platform Window. I am unsure if this is the desired behavior or not, as I am not familiar with the exact reasons we did this.

These changes were by no means difficult, but I appreciate being allowed to make them.

Please let me know any points I missed, or anything I should do differently.