### PR TITLE
Version bump to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]


### PR DESCRIPTION
#840 only added a few methods:
  - `WindowBuilder::from_winit_builder`
  - `Window::as_winit_window`
  - `Window::as_winit_window_mut`

So I suppose it didn't break the API but just added a feature, hence the patch version bump instead of the minor one.