### PR TITLE
Readd Clone to WindowBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub struct Window {
 }
 
 /// Object that allows you to build windows.
-// #[derive(Clone)]
+#[derive(Clone)]
 pub struct WindowBuilder<'a> {
     winit_builder: winit::WindowBuilder,
 


### PR DESCRIPTION
Adds the `Clone` auto-derive back to `WindowBuilder` after it was somehow removed in #819. Only tested on Windows.