### PR TITLE
Update to new winit 0.6 `EventsLoop` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 lazy_static = "0.2.0"
 libc = "0.2"
 shared_library = "0.1.0"
-winit = "0.5.10"
+winit = "0.6"
 
 [build-dependencies]
 gl_generator = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 lazy_static = "0.2.0"
 libc = "0.2"
 shared_library = "0.1.0"
-winit = "0.6.2"
+winit = "0.6.3"
 
 [build-dependencies]
 gl_generator = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 lazy_static = "0.2.0"
 libc = "0.2"
 shared_library = "0.1.0"
-winit = "0.6"
+winit = "0.6.2"
 
 [build-dependencies]
 gl_generator = "0.5"
@@ -42,5 +42,5 @@ dwmapi-sys = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 osmesa-sys = "0.1.0"
-wayland-client = { version = "0.7.4", features = ["egl", "dlopen"] }
+wayland-client = { version = "0.8.6", features = ["egl", "dlopen"] }
 x11-dl = "2.4"

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,34 +1,51 @@
 extern crate glutin;
 
-use glutin::{Event, ElementState, MouseCursor};
+use glutin::MouseCursor;
 
 mod support;
 
 fn main() {
-    let window = glutin::WindowBuilder::new().build().unwrap();
-    window.set_title("A fantastic window!");
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .build(&events_loop)
+        .unwrap();
+
     unsafe { window.make_current().unwrap() };
 
     let context = support::load(&window);
-    let cursors = [MouseCursor::Default, MouseCursor::Crosshair, MouseCursor::Hand, MouseCursor::Arrow, MouseCursor::Move, MouseCursor::Text, MouseCursor::Wait, MouseCursor::Help, MouseCursor::Progress, MouseCursor::NotAllowed, MouseCursor::ContextMenu, MouseCursor::NoneCursor, MouseCursor::Cell, MouseCursor::VerticalText, MouseCursor::Alias, MouseCursor::Copy, MouseCursor::NoDrop, MouseCursor::Grab, MouseCursor::Grabbing, MouseCursor::AllScroll, MouseCursor::ZoomIn, MouseCursor::ZoomOut, MouseCursor::EResize, MouseCursor::NResize, MouseCursor::NeResize, MouseCursor::NwResize, MouseCursor::SResize, MouseCursor::SeResize, MouseCursor::SwResize, MouseCursor::WResize, MouseCursor::EwResize, MouseCursor::NsResize, MouseCursor::NeswResize, MouseCursor::NwseResize, MouseCursor::ColResize, MouseCursor::RowResize];
+    let cursors = [
+        MouseCursor::Default, MouseCursor::Crosshair, MouseCursor::Hand, MouseCursor::Arrow,
+        MouseCursor::Move, MouseCursor::Text, MouseCursor::Wait, MouseCursor::Help,
+        MouseCursor::Progress, MouseCursor::NotAllowed, MouseCursor::ContextMenu,
+        MouseCursor::NoneCursor, MouseCursor::Cell, MouseCursor::VerticalText, MouseCursor::Alias,
+        MouseCursor::Copy, MouseCursor::NoDrop, MouseCursor::Grab, MouseCursor::Grabbing,
+        MouseCursor::AllScroll, MouseCursor::ZoomIn, MouseCursor::ZoomOut, MouseCursor::EResize,
+        MouseCursor::NResize, MouseCursor::NeResize, MouseCursor::NwResize, MouseCursor::SResize,
+        MouseCursor::SeResize, MouseCursor::SwResize, MouseCursor::WResize, MouseCursor::EwResize,
+        MouseCursor::NsResize, MouseCursor::NeswResize, MouseCursor::NwseResize,
+        MouseCursor::ColResize, MouseCursor::RowResize,
+    ];
     let mut cursor_idx = 0;
 
-    for event in window.wait_events() {
+    events_loop.run_forever(|event| {
         match event {
-            Event::KeyboardInput(ElementState::Pressed, _, _) => {
-                println!("Setting cursor to \"{:?}\"", cursors[cursor_idx]);
-                window.set_cursor(cursors[cursor_idx]);
-                if cursor_idx < cursors.len() - 1 {
-                    cursor_idx += 1;
-                } else {
-                    cursor_idx = 0;
-                }
+            glutin::Event::WindowEvent { event, .. } => match event {
+                glutin::WindowEvent::KeyboardInput(glutin::ElementState::Pressed, _, _) => {
+                    println!("Setting cursor to \"{:?}\"", cursors[cursor_idx]);
+                    window.set_cursor(cursors[cursor_idx]);
+                    if cursor_idx < cursors.len() - 1 {
+                        cursor_idx += 1;
+                    } else {
+                        cursor_idx = 0;
+                    }
+                },
+                glutin::WindowEvent::Closed => events_loop.interrupt(),
+                _ => (),
             },
-            Event::Closed => break,
-            _ => (),
         }
 
         context.draw_frame((0.0, 1.0, 0.0, 1.0));
         window.swap_buffers().unwrap();
-    }
+    });
 }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -31,7 +31,7 @@ fn main() {
     events_loop.run_forever(|event| {
         match event {
             glutin::Event::WindowEvent { event, .. } => match event {
-                glutin::WindowEvent::KeyboardInput(glutin::ElementState::Pressed, _, _) => {
+                glutin::WindowEvent::KeyboardInput(glutin::ElementState::Pressed, _, _, _) => {
                     println!("Setting cursor to \"{:?}\"", cursors[cursor_idx]);
                     window.set_cursor(cursors[cursor_idx]);
                     if cursor_idx < cursors.len() - 1 {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -24,27 +24,30 @@ fn main() {
         monitor
     };
 
+    let events_loop = glutin::EventsLoop::new();
     let window = glutin::WindowBuilder::new()
         .with_title("Hello world!")
         .with_fullscreen(monitor)
-        .build()
+        .build(&events_loop)
         .unwrap();
 
     let _ = unsafe { window.make_current() };
-
     
     let context = support::load(&window);
 
-    for event in window.wait_events() {
+    events_loop.run_forever(|event| {
+        println!("{:?}", event);
+
         context.draw_frame((0.0, 1.0, 0.0, 1.0));
         let _ = window.swap_buffers();
 
-        println!("{:?}", event);
-
         match event {
-            glutin::Event::Closed => break,
-            glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) => break,
-            _ => ()
+            glutin::Event::WindowEvent { event, .. } => match event {
+                glutin::WindowEvent::Closed => events_loop.interrupt(),
+                glutin::WindowEvent::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) =>
+                    events_loop.interrupt(),
+                _ => (),
+            },
         }
-    }
+    });
 }

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -44,7 +44,7 @@ fn main() {
         match event {
             glutin::Event::WindowEvent { event, .. } => match event {
                 glutin::WindowEvent::Closed => events_loop.interrupt(),
-                glutin::WindowEvent::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) =>
+                glutin::WindowEvent::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape), _) =>
                     events_loop.interrupt(),
                 _ => (),
             },

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -1,41 +1,46 @@
 extern crate glutin;
 
-use glutin::{Event, ElementState};
-
 mod support;
 
 fn main() {
-    let window = glutin::WindowBuilder::new().build().unwrap();
-    window.set_title("glutin - Cursor grabbing test");
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new()
+        .with_title("glutin - Cursor grabbing test")
+        .build(&events_loop)
+        .unwrap();
+
     let _ = unsafe { window.make_current() };
 
     let context = support::load(&window);
     let mut grabbed = false;
 
-    for event in window.wait_events() {
+    events_loop.run_forever(|event| {
         match event {
-            Event::KeyboardInput(ElementState::Pressed, _, _) => {
-                if grabbed {
-                    grabbed = false;
-                    window.set_cursor_state(glutin::CursorState::Normal)
-                          .ok().expect("could not ungrab mouse cursor");
-                } else {
-                    grabbed = true;
-                    window.set_cursor_state(glutin::CursorState::Grab)
-                          .ok().expect("could not grab mouse cursor");
-                }
+            glutin::Event::WindowEvent { event, .. } => match event {
+
+                glutin::WindowEvent::KeyboardInput(glutin::ElementState::Pressed, _, _) => {
+                    if grabbed {
+                        grabbed = false;
+                        window.set_cursor_state(glutin::CursorState::Normal)
+                              .ok().expect("could not ungrab mouse cursor");
+                    } else {
+                        grabbed = true;
+                        window.set_cursor_state(glutin::CursorState::Grab)
+                              .ok().expect("could not grab mouse cursor");
+                    }
+                },
+
+                glutin::WindowEvent::Closed => events_loop.interrupt(),
+
+                a @ glutin::WindowEvent::MouseMoved(_, _) => {
+                    println!("{:?}", a);
+                },
+
+                _ => (),
             },
-
-            Event::Closed => break,
-
-            a @ Event::MouseMoved(_, _) => {
-                println!("{:?}", a);
-            },
-
-            _ => (),
         }
 
         context.draw_frame((0.0, 1.0, 0.0, 1.0));
         let _ = window.swap_buffers();
-    }
+    });
 }

--- a/examples/grabbing.rs
+++ b/examples/grabbing.rs
@@ -18,7 +18,7 @@ fn main() {
         match event {
             glutin::Event::WindowEvent { event, .. } => match event {
 
-                glutin::WindowEvent::KeyboardInput(glutin::ElementState::Pressed, _, _) => {
+                glutin::WindowEvent::KeyboardInput(glutin::ElementState::Pressed, _, _, _) => {
                     if grabbed {
                         grabbed = false;
                         window.set_cursor_state(glutin::CursorState::Normal)

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,43 +1,50 @@
 extern crate glutin;
 
-use std::thread;
-
 mod support;
 
 fn main() {
-    let window1 = glutin::WindowBuilder::new().build().unwrap();
-    let window2 = glutin::WindowBuilder::new().build().unwrap();
-    let window3 = glutin::WindowBuilder::new().build().unwrap();
+    let events_loop = glutin::EventsLoop::new();
 
-    let t1 = thread::spawn(move || {
-        run(window1, (0.0, 1.0, 0.0, 1.0));
-    });
+    let window1 = glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let window2 = glutin::WindowBuilder::new().build(&events_loop).unwrap();
+    let window3 = glutin::WindowBuilder::new().build(&events_loop).unwrap();
 
-    let t2 = thread::spawn(move || {
-        run(window2, (0.0, 0.0, 1.0, 1.0));
-    });
+    let mut num_windows = 3;
 
-    let t3 = thread::spawn(move || {
-        run(window3, (1.0, 0.0, 0.0, 1.0));
-    });
+    let context1 = support::load(&window1);
+    let context2 = support::load(&window2);
+    let context3 = support::load(&window3);
 
-    let _ = t1.join();
-    let _ = t2.join();
-    let _ = t3.join();
-}
-
-fn run(window: glutin::Window, color: (f32, f32, f32, f32)) {
-    let _ = unsafe { window.make_current() };
-
-    let context = support::load(&window);
-
-    for event in window.wait_events() {
+    fn draw_to_window(window: &glutin::Window, context: &support::Context, color: (f32, f32, f32, f32)) {
+        let _ = unsafe { window.make_current() };
         context.draw_frame(color);
-        let _ = window.swap_buffers();
+    }
+
+    events_loop.run_forever(|event| {
+        println!("{:?}", event);
 
         match event {
-            glutin::Event::Closed => break,
-            _ => ()
+            glutin::Event::WindowEvent { event: glutin::WindowEvent::Closed, window_id } => {
+                if window_id == window1.id() {
+                    println!("Window 1 has been closed")
+                } else if window_id == window2.id() {
+                    println!("Window 2 has been closed")
+                } else if window_id == window3.id() {
+                    println!("Window 3 has been closed");
+                } else {
+                    unreachable!()
+                }
+
+                num_windows -= 1;
+                if num_windows == 0 {
+                    events_loop.interrupt();
+                }
+            },
+            _ => (),
         }
-    }
+
+        draw_to_window(&window1, &context1, (0.0, 1.0, 0.0, 1.0));
+        draw_to_window(&window2, &context2, (0.0, 0.0, 1.0, 1.0));
+        draw_to_window(&window3, &context3, (1.0, 0.0, 0.0, 1.0));
+    });
 }

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -11,13 +11,17 @@ fn main() {
 
     let mut num_windows = 3;
 
+    let _ = unsafe { window1.make_current() };
     let context1 = support::load(&window1);
+    let _ = unsafe { window2.make_current() };
     let context2 = support::load(&window2);
+    let _ = unsafe { window3.make_current() };
     let context3 = support::load(&window3);
 
     fn draw_to_window(window: &glutin::Window, context: &support::Context, color: (f32, f32, f32, f32)) {
         let _ = unsafe { window.make_current() };
         context.draw_frame(color);
+        let _ = window.swap_buffers();
     }
 
     events_loop.run_forever(|event| {

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -2,31 +2,31 @@ extern crate glutin;
 
 mod support;
 
-fn resize_callback(width: u32, height: u32) {
-    println!("Window resized to {}x{}", width, height);
-}
-
 fn main() {
-    let mut window = glutin::WindowBuilder::new().with_decorations(false)
-                                                 .with_transparency(true)
-                                                 .build().unwrap();
-    window.set_title("A fantastic window!");
-    window.set_window_resize_callback(Some(resize_callback as fn(u32, u32)));
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_decorations(false)
+        .with_transparency(true)
+        .build(&events_loop)
+        .unwrap();
+
     let _ = unsafe { window.make_current() };
 
     println!("Pixel format of the window: {:?}", window.get_pixel_format());
 
     let context = support::load(&window);
 
-    for event in window.wait_events() {
+    events_loop.run_forever(|event| {
+        println!("{:?}", event);
+
         context.draw_frame((0.0, 0.0, 0.0, 0.0));
         let _ = window.swap_buffers();
 
-        println!("{:?}", event);
-
         match event {
-            glutin::Event::Closed => break,
+            glutin::Event::WindowEvent { event: glutin::WindowEvent::Closed, .. } =>
+                events_loop.interrupt(),
             _ => ()
         }
-    }
+    });
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -2,29 +2,29 @@ extern crate glutin;
 
 mod support;
 
-fn resize_callback(width: u32, height: u32) {
-    println!("Window resized to {}x{}", width, height);
-}
-
 fn main() {
-    let mut window = glutin::WindowBuilder::new().build().unwrap();
-    window.set_title("A fantastic window!");
-    window.set_window_resize_callback(Some(resize_callback as fn(u32, u32)));
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .build(&events_loop)
+        .unwrap();
+
     let _ = unsafe { window.make_current() };
 
     println!("Pixel format of the window: {:?}", window.get_pixel_format());
 
     let context = support::load(&window);
 
-    for event in window.wait_events() {
+    events_loop.run_forever(|event| {
+        println!("{:?}", event);
+
         context.draw_frame((0.0, 1.0, 0.0, 1.0));
         let _ = window.swap_buffers();
 
-        println!("{:?}", event);
-
         match event {
-            glutin::Event::Closed => break,
+            glutin::Event::WindowEvent { event: glutin::WindowEvent::Closed, .. } =>
+                events_loop.interrupt(),
             _ => ()
         }
-    }
+    });
 }

--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -33,13 +33,14 @@ pub struct PlatformSpecificWindowBuilderAttributes;
 pub struct PlatformSpecificHeadlessBuilderAttributes;
 
 impl Window {
-    pub fn new(_: &WindowAttributes,
+    pub fn new(events_loop: &winit::EventsLoop,
+               _: &WindowAttributes,
                pf_reqs: &PixelFormatRequirements,
                opengl: &GlAttributes<&Window>,
                _: &PlatformSpecificWindowBuilderAttributes,
                winit_builder: winit::WindowBuilder)
                -> Result<Window, CreationError> {
-        let winit_window = winit_builder.build().unwrap();
+        let winit_window = winit_builder.build(events_loop).unwrap();
         let opengl = opengl.clone().map_sharing(|w| &w.context);
         let native_window = unsafe { android_glue::get_native_window() };
         if native_window.is_null() {
@@ -99,14 +100,6 @@ impl Window {
         self.winit_window.set_inner_size(x, y)
     }
 
-    pub fn poll_events(&self) -> winit::PollEventsIterator {
-        self.winit_window.poll_events()
-    }
-
-    pub fn wait_events(&self) -> winit::WaitEventsIterator {
-        self.winit_window.wait_events()
-    }
-
     pub unsafe fn platform_display(&self) -> *mut libc::c_void {
         self.winit_window.platform_display()
     }
@@ -123,14 +116,6 @@ impl Window {
 
     pub unsafe fn platform_window(&self) -> *mut libc::c_void {
         self.winit_window.platform_window()
-    }
-
-    pub fn create_window_proxy(&self) -> winit::WindowProxy {
-        self.winit_window.create_window_proxy()
-    }
-
-    pub fn set_window_resize_callback(&mut self, callback: Option<fn(u32, u32)>) {
-        self.winit_window.set_window_resize_callback(callback);
     }
 
     pub fn set_cursor(&self, cursor: winit::MouseCursor) {
@@ -182,16 +167,6 @@ impl GlContext for Window {
     #[inline]
     fn get_pixel_format(&self) -> PixelFormat {
         self.context.get_pixel_format()
-    }
-}
-
-#[derive(Clone)]
-pub struct WindowProxy;
-
-impl WindowProxy {
-    #[inline]
-    pub fn wakeup_event_loop(&self) {
-        unimplemented!()
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,1 +1,1 @@
-pub use winit::{Event, TouchPhase, Touch, ScanCode, ElementState, MouseButton, MouseScrollDelta, VirtualKeyCode};
+pub use winit::{Event, WindowEvent, TouchPhase, Touch, ScanCode, ElementState, MouseButton, MouseScrollDelta, VirtualKeyCode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@ extern crate wayland_client;
 
 pub use events::*;
 pub use headless::{HeadlessRendererBuilder, HeadlessContext};
-//pub use window::{WindowProxy, PollEventsIterator, WaitEventsIterator};
 pub use window::{AvailableMonitorsIter, MonitorId, get_available_monitors, get_primary_monitor};
 pub use winit::NativeMonitorId;
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -6,7 +6,7 @@ pub use winit::os::macos::ActivationPolicy;
 
 /// Additional methods on `WindowBuilder` that are specific to MacOS.
 pub trait WindowBuilderExt<'a> {
-    fn with_activation_policy(mut self, activation_policy: ActivationPolicy) -> WindowBuilder<'a>;
+    fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder<'a>;
 }
 
 impl<'a> WindowBuilderExt<'a> for WindowBuilder<'a> {

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -1,6 +1,5 @@
 #![cfg(target_os = "android")]
 
-pub use winit::PollEventsIterator;
-pub use winit::WaitEventsIterator;
+pub use winit::EventsLoop;
 
 pub use api::android::*;

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -10,9 +10,9 @@ use PixelFormatRequirements;
 
 use api::osmesa::{self, OsMesaContext};
 
-pub use self::api_dispatch::{Window};
+pub use self::api_dispatch::{Window, EventsLoop};
 pub use self::api_dispatch::PlatformSpecificWindowBuilderAttributes;
-pub use self::api_dispatch::{WaitEventsIterator, PollEventsIterator};
+
 mod api_dispatch;
 mod wayland;
 mod x11;

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -125,6 +125,7 @@ impl Drop for Window {
 
 impl Window {
     pub fn new(
+        events_loop: &winit::EventsLoop,
         pf_reqs: &PixelFormatRequirements,
         opengl: &GlAttributes<&Window>,
         winit_builder: winit::WindowBuilder,
@@ -216,7 +217,7 @@ impl Window {
         let winit_window = winit_builder
             .with_x11_visual(&visual_infos as *const _)
             .with_x11_screen(screen_id)
-            .build().unwrap();
+            .build(events_loop).unwrap();
 
         let xlib_window = winit_window.get_xlib_window().unwrap();
         // finish creating the OpenGL context

--- a/src/platform/macos/helpers.rs
+++ b/src/platform/macos/helpers.rs
@@ -16,7 +16,7 @@ pub fn build_nsattributes<T>(pf_reqs: &PixelFormatRequirements, opengl: &GlAttri
         // https://github.com/rust-lang/rust/pull/27050
 
         (GlRequest::Latest, _, Some(GlProfile::Compatibility)) => NSOpenGLProfileVersionLegacy as u32,
-        (GlRequest::Latest, _, _) => {
+        (GlRequest::Latest, _, _) => unsafe {
             if NSAppKitVersionNumber.floor() >= NSAppKitVersionNumber10_9 {
                 NSOpenGLProfileVersion4_1Core as u32
             } else if NSAppKitVersionNumber.floor() >= NSAppKitVersionNumber10_7 {

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -113,7 +113,7 @@ unsafe impl Sync for Window {}
 
 impl Window {
     pub fn new(events_loop: &EventsLoop,
-               win_attribs: &WindowAttributes,
+               _win_attribs: &WindowAttributes,
                pf_reqs: &PixelFormatRequirements,
                opengl: &GlAttributes<&Window>,
                _pl_attribs: &PlatformSpecificWindowBuilderAttributes,
@@ -131,9 +131,10 @@ impl Window {
             _ => (),
         }
 
+        let transparent = winit_builder.window.transparent;
         let winit_window = winit_builder.build(&events_loop.winit_events_loop).unwrap();
         let view = winit_window.get_nsview() as id;
-        let (context, pf) = match Window::create_context(view, pf_reqs, opengl, win_attribs.transparent) {
+        let (context, pf) = match Window::create_context(view, pf_reqs, opengl, transparent) {
             Ok((context, pf)) => (std::sync::Arc::new(context), pf),
             Err(e) => {
                 return Err(OsError(format!("Couldn't create OpenGL context: {}", e)));

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -67,6 +67,9 @@ struct ContextMap {
     map: Mutex<HashMap<winit::WindowId, Weak<Context>>>,
 }
 
+unsafe impl Send for ContextMap {}
+unsafe impl Sync for ContextMap {}
+
 impl EventsLoop {
     /// Builds a new events loop.
     pub fn new() -> EventsLoop {

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -36,15 +36,59 @@ enum Context {
     Wgl(WglContext),
 }
 
+pub struct EventsLoop {
+    winit_events_loop: winit::EventsLoop,
+}
+
+impl EventsLoop {
+
+    /// Builds a new events loop.
+    pub fn new() -> Self {
+        EventsLoop {
+            winit_events_loop: winit::EventsLoop::new(),
+        }
+    }
+
+    /// Fetches all the events that are pending, calls the callback function for each of them,
+    /// and returns.
+    #[inline]
+    pub fn poll_events<F>(&self, mut callback: F)
+        where F: FnMut(winit::Event)
+    {
+        self.winit_events_loop.poll_events(|event| {
+            callback(event);
+        });
+    }
+
+    /// Runs forever until `interrupt()` is called. Whenever an event happens, calls the callback.
+    #[inline]
+    pub fn run_forever<F>(&self, mut callback: F)
+        where F: FnMut(winit::Event)
+    {
+        self.winit_events_loop.run_forever(|event| {
+            callback(event);
+        })
+    }
+
+    /// If we called `run_forever()`, stops the process of waiting for events.
+    #[inline]
+    pub fn interrupt(&self) {
+        self.winit_events_loop.interrupt()
+    }
+
+}
+
 impl Window {
+
     /// See the docs in the crate root file.
-    pub fn new(_: &WindowAttributes,
+    pub fn new(events_loop: &EventsLoop,
+               _: &WindowAttributes,
                pf_reqs: &PixelFormatRequirements,
                opengl: &GlAttributes<&Window>,
                egl: Option<&Egl>,
                winit_builder: winit::WindowBuilder)
                -> Result<Window, CreationError> {
-        let winit_window = winit_builder.build().unwrap();
+        let winit_window = winit_builder.build(&events_loop.winit_events_loop).unwrap();
         let opengl = opengl.clone().map_sharing(|sharing| {
             match sharing.context {
                 Context::Wgl(ref c) => c.get_hglrc(),
@@ -75,6 +119,7 @@ impl Window {
                 _ => try!(WglContext::new(&pf_reqs, &opengl, w).map(Context::Wgl)),
             }
         };
+
         Ok(Window {
             context: context,
             winit_window: winit_window,
@@ -134,28 +179,12 @@ impl Window {
         self.winit_window.set_inner_size(x, y)
     }
 
-    pub fn poll_events(&self) -> winit::PollEventsIterator {
-        self.winit_window.poll_events()
-    }
-
-    pub fn wait_events(&self) -> winit::WaitEventsIterator {
-        self.winit_window.wait_events()
-    }
-
     pub unsafe fn platform_display(&self) -> *mut libc::c_void {
         self.winit_window.platform_display()
     }
 
     pub unsafe fn platform_window(&self) -> *mut libc::c_void {
         self.winit_window.platform_window()
-    }
-
-    pub fn create_window_proxy(&self) -> winit::WindowProxy {
-        self.winit_window.create_window_proxy()
-    }
-
-    pub fn set_window_resize_callback(&mut self, callback: Option<fn(u32, u32)>) {
-        self.winit_window.set_window_resize_callback(callback);
     }
 
     pub fn set_cursor(&self, cursor: winit::MouseCursor) {
@@ -172,6 +201,10 @@ impl Window {
 
     pub fn set_cursor_state(&self, state: winit::CursorState) -> Result<(), String> {
         self.winit_window.set_cursor_state(state)
+    }
+
+    pub fn id(&self) -> winit::WindowId {
+        self.winit_window.id()
     }
 }
 


### PR DESCRIPTION
This updates `glutin`'s API to reflect `winit`'s new API introduced in tomaka/winit#126, recently published under version 0.6.0. Please see the linked PR for further details on the new API.

You can also see tomaka/winit#132 to find out how this new version of `winit` solves many old macos bugs.

So far, this PR updates the API, macos backend and all of the examples to the new winit API. I haven't updated any of the other backends yet.

If I get time soon, I'll look into making a `gen_api_transition!` macro similar to [the one used in winit](https://github.com/tomaka/winit/blob/master/src/api_transition.rs). If anyone else would like to tackle this in the mean time feel free to fork this PR and get it done!