### PR TITLE
Better error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,11 @@ impl CreationError {
 
 impl std::fmt::Display for CreationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        formatter.write_str(self.to_string())
+        formatter.write_str(self.to_string())?;
+        if let Some(err) = std::error::Error::cause(self) {
+            write!(formatter, ": {}", err)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
 * `Display` impl for `CreationError` gives the details of the cause of the error.
 * `Window::new` returns `Err` instead of panicking if it can't get an X11 connection.