### PR TITLE
Remove ambiguous, unused `WindowAttributes` parameter

### DIFF
--- a/src/platform/linux/api_dispatch.rs
+++ b/src/platform/linux/api_dispatch.rs
@@ -70,7 +70,6 @@ impl<'a> Iterator for PollEventsIterator<'a> {
 impl Window {
     #[inline]
     pub fn new(
-        _: &WindowAttributes,
         pf_reqs: &PixelFormatRequirements,
         opengl: &GlAttributes<&Window>,
         _: &PlatformSpecificWindowBuilderAttributes,

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -88,8 +88,7 @@ unsafe impl Send for Window {}
 unsafe impl Sync for Window {}
 
 impl Window {
-    pub fn new(win_attribs: &WindowAttributes,
-               pf_reqs: &PixelFormatRequirements,
+    pub fn new(pf_reqs: &PixelFormatRequirements,
                opengl: &GlAttributes<&Window>,
                _pl_attribs: &PlatformSpecificWindowBuilderAttributes,
                winit_builder: winit::WindowBuilder)

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -68,14 +68,12 @@ impl Window {
     /// See the docs in the crate root file.
     #[inline]
     pub fn new(
-        window: &WindowAttributes,
         pf_reqs: &PixelFormatRequirements,
         opengl: &GlAttributes<&Window>,
         _: &PlatformSpecificWindowBuilderAttributes,
         winit_builder: winit::WindowBuilder,
     ) -> Result<Window, CreationError> {
         window::Window::new(
-            window,
             pf_reqs,
             &opengl.clone().map_sharing(|w| &w.0),
             EGL.as_ref().map(|w| &w.0),
@@ -127,10 +125,9 @@ impl HeadlessContext {
             }
         }
         let winit_builder = winit::WindowBuilder::new().with_visibility(false);
-        let window = try!(window::Window::new(&WindowAttributes { visible: false, .. Default::default() },
-                                             pf_reqs, &opengl.clone().map_sharing(|_| unimplemented!()),            //TODO:
-                                             EGL.as_ref().map(|w| &w.0),
-                                             winit_builder));
+        let window = try!(window::Window::new(pf_reqs, &opengl.clone().map_sharing(|_| unimplemented!()),            //TODO:
+                                              EGL.as_ref().map(|w| &w.0),
+                                              winit_builder));
         Ok(HeadlessContext::HiddenWindow(window))
     }
 }

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -38,8 +38,7 @@ enum Context {
 
 impl Window {
     /// See the docs in the crate root file.
-    pub fn new(_: &WindowAttributes,
-               pf_reqs: &PixelFormatRequirements,
+    pub fn new(pf_reqs: &PixelFormatRequirements,
                opengl: &GlAttributes<&Window>,
                egl: Option<&Egl>,
                winit_builder: winit::WindowBuilder)

--- a/src/window.rs
+++ b/src/window.rs
@@ -221,8 +221,7 @@ impl<'a> WindowBuilder<'a> {
     /// Error should be very rare and only occur in case of permission denied, incompatible system,
     /// out of memory, etc.
     pub fn build(self) -> Result<Window, CreationError> {
-        let w = try!(platform::Window::new(&Default::default(),
-                                           &self.pf_reqs,
+        let w = try!(platform::Window::new(&self.pf_reqs,
                                            &self.opengl,
                                            &Default::default(),
                                            self.winit_builder));


### PR DESCRIPTION
I think this might have been left over since the pre-winit days. Rather
than being removed, it looks like `Default::default` was used instead.
This made working in the backends quite confusing as the
`WindowAttributes` are already available via the `winit::WindowBuilder`
arg and both contained different values.