### PR TITLE
Fix Gitter Image in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # glutin -  OpenGL, UTilities and INput
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/tomaka/glutin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tomaka/glutin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![](http://meritbadge.herokuapp.com/glutin)](https://crates.io/crates/glutin)
 


### PR DESCRIPTION
The space in the Gitter URL breaks the image rendering in the GitHub readme.