### PR TITLE
Publish recent changes to EventsLoop API under new version `0.8.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ extern crate wayland_client;
 
 pub use events::*;
 pub use headless::{HeadlessRendererBuilder, HeadlessContext};
-pub use window::{AvailableMonitorsIter, MonitorId, get_available_monitors, get_primary_monitor};
+pub use window::{AvailableMonitorsIter, MonitorId, WindowId, get_available_monitors, get_primary_monitor};
 pub use winit::NativeMonitorId;
 
 use std::io;


### PR DESCRIPTION
See the changes referred to in the title at #864. 

Also re-exports `WindowId` from the crate root which was missing from #864.