### PR TITLE
Bump version to expose WM_CLASS fix in winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]
@@ -14,7 +14,7 @@ build = "build.rs"
 lazy_static = "0.2.0"
 libc = "0.2"
 shared_library = "0.1.0"
-winit = "0.6.3"
+winit = "0.6.4"
 
 [build-dependencies]
 gl_generator = "0.5"


### PR DESCRIPTION
winit 0.6.4 fixes https://github.com/tomaka/winit/pull/168, which in turn fixes #879.

Depends on https://github.com/tomaka/winit/pull/171.