### PR TITLE
Fix use-after-free in glx choose_fbconfig

### DIFF
--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -507,13 +507,14 @@ unsafe fn choose_fbconfig(glx: &ffi::glx::Glx, extensions: &str, xlib: &ffi::Xli
             Some(&*configs)
         };
 
-        (xlib.XFree)(configs as *mut _);
-
-        if let Some(&conf) = config {
-            conf
+        let res = if let Some(&conf) = config {
+            Ok(conf)
         } else {
-            return Err(());
-        }
+            Err(())
+        };
+
+        (xlib.XFree)(configs as *mut _);
+        res?
     };
 
     let get_attrib = |attrib: c_int| -> i32 {


### PR DESCRIPTION
This was coming up as an invalid read inside free'd memory in Valgrind.

<details><summary>Dirty Valgrind log</summary>
<pre><code>==1646== Memcheck, a memory error detector
==1646== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==1646== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==1646== Command: target/debug/examples/window
==1646== 
==1646== Invalid read of size 8
==1646==    at 0x16CEAF: glutin::api::glx::choose_fbconfig::h40191a9550f82929 (mod.rs:512)
==1646==    by 0x16A21E: glutin::api::glx::Context::new::hbc4172f49c6bd6e3 (mod.rs:81)
==1646==    by 0x16FC75: glutin::platform::platform::x11::Window::new::ha055cd0eb7d76bf2 (x11.rs:158)
==1646==    by 0x16DCFE: glutin::platform::platform::api_dispatch::Window::new::h4cd90c67ab006e57 (api_dispatch.rs:124)
==1646==    by 0x1713E1: glutin::window::_$LT$impl$u20$glutin..WindowBuilder$LT$$u27$a$GT$$GT$::build::h50ff7ec9a0460d4c (window.rs:223)
==1646==    by 0x1366C1: window::main::heee647e8844b1ab6 (window.rs:10)
==1646==    by 0x293C1A: __rust_maybe_catch_panic (lib.rs:98)
==1646==    by 0x28D501: try<(),fn()> (panicking.rs:433)
==1646==    by 0x28D501: catch_unwind<fn(),()> (panic.rs:361)
==1646==    by 0x28D501: std::rt::lang_start::h8126425a59d3b4a0 (rt.rs:57)
==1646==    by 0x142FE2: main (in /home/jwilm/code/glutin/target/debug/examples/window)
==1646==  Address 0x5d99300 is 0 bytes inside a block of size 80 free'd
==1646==    at 0x4C2EDEB: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1646==    by 0x65A10A8: XFree (in /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0)
==1646==    by 0x16CE7E: glutin::api::glx::choose_fbconfig::h40191a9550f82929 (mod.rs:510)
==1646==    by 0x16A21E: glutin::api::glx::Context::new::hbc4172f49c6bd6e3 (mod.rs:81)
==1646==    by 0x16FC75: glutin::platform::platform::x11::Window::new::ha055cd0eb7d76bf2 (x11.rs:158)
==1646==    by 0x16DCFE: glutin::platform::platform::api_dispatch::Window::new::h4cd90c67ab006e57 (api_dispatch.rs:124)
==1646==    by 0x1713E1: glutin::window::_$LT$impl$u20$glutin..WindowBuilder$LT$$u27$a$GT$$GT$::build::h50ff7ec9a0460d4c (window.rs:223)
==1646==    by 0x1366C1: window::main::heee647e8844b1ab6 (window.rs:10)
==1646==    by 0x293C1A: __rust_maybe_catch_panic (lib.rs:98)
==1646==    by 0x28D501: try<(),fn()> (panicking.rs:433)
==1646==    by 0x28D501: catch_unwind<fn(),()> (panic.rs:361)
==1646==    by 0x28D501: std::rt::lang_start::h8126425a59d3b4a0 (rt.rs:57)
==1646==    by 0x142FE2: main (in /home/jwilm/code/glutin/target/debug/examples/window)
==1646==  Block was alloc'd at
==1646==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1646==    by 0x8747C0F: glXChooseFBConfig (in /usr/lib/nvidia-381/libGLX_nvidia.so.381.09)
==1646==    by 0x7F9F259: glXChooseFBConfig (in /usr/lib/nvidia-381/libGLX.so.0)
==1646==    by 0x17A15C: glutin::api::glx::ffi::glx::Glx::ChooseFBConfig::h808d55ddde66de9e (in /home/jwilm/code/glutin/target/debug/examples/window)
==1646==    by 0x16CD29: glutin::api::glx::choose_fbconfig::h40191a9550f82929 (mod.rs:491)
==1646==    by 0x16A21E: glutin::api::glx::Context::new::hbc4172f49c6bd6e3 (mod.rs:81)
==1646==    by 0x16FC75: glutin::platform::platform::x11::Window::new::ha055cd0eb7d76bf2 (x11.rs:158)
==1646==    by 0x16DCFE: glutin::platform::platform::api_dispatch::Window::new::h4cd90c67ab006e57 (api_dispatch.rs:124)
==1646==    by 0x1713E1: glutin::window::_$LT$impl$u20$glutin..WindowBuilder$LT$$u27$a$GT$$GT$::build::h50ff7ec9a0460d4c (window.rs:223)
==1646==    by 0x1366C1: window::main::heee647e8844b1ab6 (window.rs:10)
==1646==    by 0x293C1A: __rust_maybe_catch_panic (lib.rs:98)
==1646==    by 0x28D501: try<(),fn()> (panicking.rs:433)
==1646==    by 0x28D501: catch_unwind<fn(),()> (panic.rs:361)
==1646==    by 0x28D501: std::rt::lang_start::h8126425a59d3b4a0 (rt.rs:57)
==1646== 
Pixel format of the window: PixelFormat { hardware_accelerated: true, color_bits: 24, alpha_bits: 8, depth_bits: 24, stencil_bits: 8, stereoscopy: false, double_buffer: true, multisampling: None, srgb: true }
OpenGL version 4.5.0 NVIDIA 381.09</code></pre>
</details>

<details><summary>Valgrind log after this patch</summary>
<pre><code>==17056== Memcheck, a memory error detector
==17056== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==17056== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==17056== Command: target/debug/examples/window
==17056== 
Pixel format of the window: PixelFormat { hardware_accelerated: true, color_bits: 24, alpha_bits: 8, depth_bits: 24, stencil_bits: 8, stereoscopy: false, double_buffer: true, multisampling: None, srgb: true }
OpenGL version 4.5.0 NVIDIA 381.09</code></pre>
</details>

<p></p>

If you want to repro, it should be possible just running the `window` example.