### PR TITLE
Fix and update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,17 @@ extern crate glutin;
 extern crate libc;
 
 fn main() {
-    let window = glutin::Window::new().unwrap();
+    let events_loop = glutin::EventsLoop::new();
+    let window = glutin::WindowBuilder::new()
+        .with_title("Hello, world!".to_string())
+        .with_dimensions(1024, 768)
+        .with_vsync()
+        .build(&events_loop)
+        .unwrap();
 
-    unsafe { window.make_current() };
+    unsafe {
+        window.make_current()
+    }.unwrap();
 
     unsafe {
         gl::load_with(|symbol| window.get_proc_address(symbol) as *const _);
@@ -51,14 +59,22 @@ fn main() {
         gl::ClearColor(0.0, 1.0, 0.0, 1.0);
     }
 
-    for event in window.wait_events() {
-        unsafe { gl::Clear(gl::COLOR_BUFFER_BIT) };
-        window.swap_buffers();
+    let mut running = true;
+    while running {
+        events_loop.poll_events(|event| {
+            match event {
+                glutin::Event::WindowEvent{ event: glutin::WindowEvent::Closed, .. } => {
+                    running = false;
+                },
+                _ => ()
+            }
+        });
 
-        match event {
-            glutin::Event::Closed => break,
-            _ => ()
+        unsafe {
+            gl::Clear(gl::COLOR_BUFFER_BIT);
         }
+
+        window.swap_buffers().unwrap();
     }
 }
 ```


### PR DESCRIPTION
Changes include:
* Update to glutin 0.8.0 API
* Explicitly unwrap() to avoid compiler warnings
* Use builder API to specify dimensions, title, and v-sync
* Use traditional update loop, which avoids redrawing multiple times per sync when lots of events are happening