### PR TITLE
Don't use wayland_client specific types in winit's API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ dwmapi-sys = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 osmesa-sys = "0.1.0"
-wayland-client = { version = "0.8.6", features = ["egl", "dlopen"] }
+wayland-client = { version = "0.9.5", features = ["egl", "dlopen"] }
 x11-dl = "2.4"

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -91,8 +91,8 @@ impl Window {
         let winit_window = winit_builder.build(&events_loop.winit_events_loop).unwrap();
         let wayland_window = {
             let (w, h) = winit_window.get_inner_size().unwrap();
-            let surface = winit_window.get_wayland_client_surface().unwrap();
-            let egl_surface = wegl::WlEglSurface::new(surface, w as i32, h as i32);
+            let surface = winit_window.get_wayland_surface().unwrap();
+            let egl_surface = unsafe { wegl::WlEglSurface::new_from_raw(surface as *mut _, w as i32, h as i32) };
             let context = {
                 let libegl = unsafe { dlopen::dlopen(b"libEGL.so\0".as_ptr() as *const _, dlopen::RTLD_NOW) };
                 if libegl.is_null() {


### PR DESCRIPTION
Given the recent changes in wayland-client, this strongly-typed interface between winit and glutin regarding wayland types is not needed anymore.

This PR effectively removes the need for winit to expose wayland-client's types, as glutin will not depend on them anymore.

Effectively removing them from winit will however likely require a breaking version bump from winit (as older versions of glutin still will depend on it), so we'll probably be able to do it next time such a bump occurs.