### PR TITLE
Enable option to not switch to dedicated GPU on mac also with an integrated GPU

### DIFF
--- a/src/platform/macos/helpers.rs
+++ b/src/platform/macos/helpers.rs
@@ -55,6 +55,7 @@ pub fn build_nsattributes<T>(pf_reqs: &PixelFormatRequirements, opengl: &GlAttri
         NSOpenGLPFAAlphaSize as u32, alpha_depth as u32,
         NSOpenGLPFADepthSize as u32, pf_reqs.depth_bits.unwrap_or(24) as u32,
         NSOpenGLPFAStencilSize as u32, pf_reqs.stencil_bits.unwrap_or(8) as u32,
+        NSOpenGLPFAAllowOfflineRenderers as u32,
         NSOpenGLPFAOpenGLProfile as u32, profile,
     ];
 


### PR DESCRIPTION
Adding this flag allows an app built with glutin to run without triggering a switch to the dedicated GPU on a mac (eg on a macbook with low power intel GPU and high power dedicated GPU).

This is mainly for [this issue on the alacritty project](https://github.com/jwilm/alacritty/issues/210)

From testing, the app also needs to set `NSSupportsAutomaticGraphicsSwitching` to `true` in the Info.plist in its app bundle to stop the GPU switch. That means this flag is probably OK to add by default since app behaviour won't change without also having that Info.plist setting.

There are some details about multiple GPU support in [this technical note](https://developer.apple.com/library/content/technotes/tn2229/_index.html)