### PR TITLE
macos: is_current needs NSAutoreleasePool

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -138,13 +138,17 @@ impl Context {
     #[inline]
     pub fn is_current(&self) -> bool {
         unsafe {
+            let pool = NSAutoreleasePool::new(nil);
             let current = NSOpenGLContext::currentContext(nil);
+            let mut res = false;
             if current != nil {
                 let is_equal: BOOL = msg_send![current, isEqual:*self.gl];
-                is_equal != NO
+                res = is_equal != NO
             } else {
-                false
+                res = false
             }
+            let _: () = msg_send![pool, release];
+            res
         }
     }
 


### PR DESCRIPTION
Hi!
Thank you for glium, glutin, winit :)
  
Please consider merging 'On macos the Context::is_current seems to lack the NSAutoreleasePool.' 
its also is probably a fix for https://github.com/glium/glium/issues/1481

In glium teapot example every time the teapot is moved out of screen using wasd keys  +n kb autorelease content gets leaked

before:
<img width="1288" alt="screenshot 2017-08-20 18 30 07" src="https://user-images.githubusercontent.com/65818/29497124-c50824ee-85e2-11e7-8fe9-19a8bec4164d.png">

after:
<img width="1012" alt="screenshot 2017-08-20 19 54 04" src="https://user-images.githubusercontent.com/65818/29497134-eeabe1a0-85e2-11e7-8c3f-9384f9be366f.png">

here are instruments allocation traces:
https://www.dropbox.com/sh/7fotvmu4j5pwk11/AAD0Gc7ofkYm7-Kt2Lik8V2ra?dl=0
the teapot_glutin_master is before and teapot_after_the_fix is after the fix.

noticed the same in citybound game

before:
<img width="1367" alt="screenshot 2017-08-20 16 26 10" src="https://user-images.githubusercontent.com/65818/29497142-1443eb42-85e3-11e7-96c0-8df587ca3a21.png">

after:
<img width="1030" alt="screenshot 2017-08-20 16 28 19" src="https://user-images.githubusercontent.com/65818/29497148-28cb677a-85e3-11e7-80ee-df4aacbbffcc.png">
