### PR TITLE
Enable off-main-thread rendering on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,10 @@ impl GlWindow {
     pub fn context(&self) -> &Context {
         &self.context
     }
+
+    pub fn split(self) -> (Window, Context) {
+        (self.window, self.context)
+    }
 }
 
 impl GlContext for Context {

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -37,6 +37,10 @@ pub struct Context {
     pixel_format: PixelFormat,
 }
 
+/// according to https://developer.apple.com/library/content/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_threading/opengl_threading.html
+/// it is safe to use an `NSOpenGLContext` from multiple threads provided only one thread does so at a time.
+unsafe impl Send for Context {}
+
 impl Context {
 
     pub fn new(


### PR DESCRIPTION
In https://github.com/servo/webrender/issues/1640 we discussed how Firefox
(and probably also other browsers) have a compositor thread, which is not the
main thread, that does all their OpenGL calls. In glutin this kind of
architecture doesn't seem to be possible right now since it's not possible to
split the `GlWindow` into the window and the context, and the `Context`
doesn't implement `Send` on macOS.

The following two changes allow such architectures:
- Implement `Send` for `Context` on macOS. The Apple docs suggest that this is correct.
- Add a `split` method to `GlWindow` that allows obtaining an owned `Window` and `Context`.

cc @mitchmindtree @mstange @glennw 