### PR TITLE
Implement access of raw context handles

### DIFF
--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -16,7 +16,6 @@ use PixelFormatRequirements;
 
 use api::egl;
 use api::egl::Context as EglContext;
-use os::GlContextExt;
 
 mod ffi;
 
@@ -79,14 +78,10 @@ impl Context {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.egl_context.get_pixel_format()
     }
-}
-
-impl GlContextExt for Context {
-    type Handle = egl::ffi::egl::types::EGLContext;
 
     #[inline]
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
-        self.egl_context.as_mut_ptr()
+    pub unsafe fn raw_handle(&self) -> egl::ffi::EGLContext {
+        self.egl_context.raw_handle()
     }
 }
 
@@ -145,13 +140,9 @@ impl HeadlessContext {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.0.get_pixel_format()
     }
-}
-
-impl GlContextExt for HeadlessContext {
-    type Handle = egl::ffi::egl::types::EGLContext;
 
     #[inline]
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
-        self.0.as_mut_ptr()
+    pub unsafe fn raw_handle(&self) -> egl::ffi::EGLContext {
+        self.0.raw_handle()
     }
 }

--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -16,15 +16,13 @@ use PixelFormatRequirements;
 
 use api::egl;
 use api::egl::Context as EglContext;
+use os::GlContextExt;
 
 mod ffi;
 
 pub struct Context {
     egl_context: EglContext,
 }
-
-#[derive(Clone, Default)]
-pub struct PlatformSpecificHeadlessBuilderAttributes;
 
 impl Context {
     pub fn new(
@@ -83,6 +81,18 @@ impl Context {
     }
 }
 
+impl GlContextExt for Context {
+    type Handle = egl::ffi::egl::types::EGLContext;
+
+    #[inline]
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.egl_context.as_mut_ptr()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct PlatformSpecificHeadlessBuilderAttributes;
+
 pub struct HeadlessContext(EglContext);
 
 unsafe impl Send for HeadlessContext {}
@@ -134,5 +144,14 @@ impl HeadlessContext {
     #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.0.get_pixel_format()
+    }
+}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = egl::ffi::egl::types::EGLContext;
+
+    #[inline]
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.0.as_mut_ptr()
     }
 }

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -111,7 +111,6 @@ impl Context {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.opengl.get_pixel_format()
     }
-
 }
 
 impl Drop for Context {

--- a/src/api/egl/ffi.rs
+++ b/src/api/egl/ffi.rs
@@ -1,9 +1,11 @@
 #![allow(non_camel_case_types)]
 
-use libc;
-
 #[cfg(target_os = "windows")]
 extern crate winapi;
+
+pub use self::egl::types::EGLContext;
+
+use libc;
 
 pub mod egl {
     pub type khronos_utime_nanoseconds_t = super::khronos_utime_nanoseconds_t;

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -320,6 +320,11 @@ impl Context {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
     }
+
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> ffi::egl::types::EGLContext {
+        self.context
+    }
 }
 
 unsafe impl Send for Context {}

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -322,7 +322,7 @@ impl Context {
     }
 
     #[inline]
-    pub unsafe fn as_mut_ptr(&self) -> ffi::egl::types::EGLContext {
+    pub unsafe fn raw_handle(&self) -> ffi::egl::types::EGLContext {
         self.context
     }
 }

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -145,7 +145,7 @@ impl Context {
     }
 
     #[inline]
-    pub unsafe fn as_mut_ptr(&self) -> ffi::GLXContext {
+    pub unsafe fn raw_handle(&self) -> ffi::GLXContext {
         self.context
     }
 }

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -143,6 +143,11 @@ impl Context {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
     }
+
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> ffi::GLXContext {
+        self.context
+    }
 }
 
 unsafe impl Send for Context {}

--- a/src/api/ios/mod.rs
+++ b/src/api/ios/mod.rs
@@ -343,12 +343,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {
-    }
+    pub fn set_window_resize_callback(&mut self, _: Option<fn(u32, u32)>) {}
 
     #[inline]
-    pub fn set_cursor(&self, _: MouseCursor) {
-    }
+    pub fn set_cursor(&self, _: MouseCursor) {}
 
     #[inline]
     pub fn set_cursor_state(&self, _: CursorState) -> Result<(), String> {
@@ -369,7 +367,6 @@ impl Window {
     pub fn create_window_proxy(&self) -> WindowProxy {
         WindowProxy
     }
-
 }
 
 impl GlContext for Window {
@@ -426,7 +423,6 @@ impl WindowProxy {
         unimplemented!()
     }
 }
-
 
 impl<'a> Iterator for WaitEventsIterator<'a> {
     type Item = Event;

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -192,7 +192,7 @@ impl OsMesaContext {
     }
 
     #[inline]
-    pub unsafe fn as_mut_ptr(&self) -> osmesa_sys::OSMesaContext {
+    pub unsafe fn raw_handle(&self) -> osmesa_sys::OSMesaContext {
         self.context
     }
 }

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -2,11 +2,6 @@
 
 extern crate osmesa_sys;
 
-use std::error::Error;
-use std::ffi::CString;
-use std::fmt::{Debug, Display, Error as FormatError, Formatter};
-use std::{mem, ptr};
-
 use Api;
 use ContextError;
 use CreationError;
@@ -17,6 +12,12 @@ use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
 use libc;
+
+use std::error::Error;
+use std::ffi::CString;
+use std::fmt::{Debug, Display, Error as FormatError, Formatter};
+use std::{mem, ptr};
+use std::os::raw::c_void;
 
 pub mod ffi {
     pub use super::osmesa_sys::OSMesaContext;
@@ -192,8 +193,8 @@ impl OsMesaContext {
     }
 
     #[inline]
-    pub unsafe fn raw_handle(&self) -> osmesa_sys::OSMesaContext {
-        self.context
+    pub unsafe fn raw_handle(&self) -> *mut c_void {
+        self.context as *mut _
     }
 }
 

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -18,6 +18,10 @@ use PixelFormatRequirements;
 use Robustness;
 use libc;
 
+pub mod ffi {
+    pub use super::osmesa_sys::OSMesaContext;
+}
+
 pub struct OsMesaContext {
     context: osmesa_sys::OSMesaContext,
     buffer: Vec<u32>,
@@ -185,6 +189,11 @@ impl OsMesaContext {
     #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         unimplemented!();
+    }
+
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> osmesa_sys::OSMesaContext {
+        self.context
     }
 }
 

--- a/src/api/wgl/mod.rs
+++ b/src/api/wgl/mod.rs
@@ -199,7 +199,7 @@ impl Context {
     }
 
     #[inline]
-    pub unsafe fn as_mut_ptr(&self) -> winapi::HDC {
+    pub unsafe fn raw_handle(&self) -> winapi::HDC {
         self.hdc
     }
 }

--- a/src/api/wgl/mod.rs
+++ b/src/api/wgl/mod.rs
@@ -197,11 +197,6 @@ impl Context {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
     }
-
-    #[inline]
-    pub unsafe fn raw_handle(&self) -> winapi::HDC {
-        self.hdc
-    }
 }
 
 unsafe impl Send for Context {}

--- a/src/api/wgl/mod.rs
+++ b/src/api/wgl/mod.rs
@@ -16,8 +16,7 @@ use self::make_current_guard::CurrentContextGuard;
 use std::ffi::{CStr, CString, OsStr};
 use std::os::raw::{c_void, c_int};
 use std::os::windows::ffi::OsStrExt;
-use std::{mem, ptr};
-use std::io;
+use std::{io, mem, ptr};
 
 use winapi;
 use kernel32;
@@ -197,6 +196,11 @@ impl Context {
     #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
+    }
+
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> winapi::HDC {
+        self.hdc
     }
 }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -9,6 +9,7 @@ use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
 
+use os::GlContextExt;
 use platform;
 
 /// Object that allows you to build headless contexts.
@@ -143,3 +144,11 @@ impl GlContext for HeadlessContext {
     }
 }
 
+impl GlContextExt for HeadlessContext {
+    type Handle = <platform::HeadlessContext as GlContextExt>::Handle;
+
+    #[inline]
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.context.as_mut_ptr()
+    }
+}

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -9,7 +9,6 @@ use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
 
-use os::GlContextExt;
 use platform;
 
 /// Object that allows you to build headless contexts.
@@ -94,7 +93,7 @@ impl<'a> HeadlessRendererBuilder<'a> {
 
 /// Represents a headless OpenGL context.
 pub struct HeadlessContext {
-    context: platform::HeadlessContext,
+    pub(crate) context: platform::HeadlessContext,
 }
 
 impl GlContext for HeadlessContext {
@@ -141,14 +140,5 @@ impl GlContext for HeadlessContext {
     fn resize(&self, _width: u32, _height: u32) {
         // This method does not mean anything for a HeadlessContext.
         unimplemented!()
-    }
-}
-
-impl GlContextExt for HeadlessContext {
-    type Handle = <platform::HeadlessContext as GlContextExt>::Handle;
-
-    #[inline]
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
-        self.context.as_mut_ptr()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,14 @@ impl GlContext for Context {
     }
 }
 
+impl os::GlContextExt for Context {
+    type Handle = <platform::Context as os::GlContextExt>::Handle;
+
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.context.as_mut_ptr()
+    }
+}
+
 impl GlContext for GlWindow {
     unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.context.make_current()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,14 +367,6 @@ impl GlContext for Context {
     }
 }
 
-impl os::GlContextExt for Context {
-    type Handle = <platform::Context as os::GlContextExt>::Handle;
-
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
-        self.context.as_mut_ptr()
-    }
-}
-
 impl GlContext for GlWindow {
     unsafe fn make_current(&self) -> Result<(), ContextError> {
         self.context.make_current()

--- a/src/os/android.rs
+++ b/src/os/android.rs
@@ -2,4 +2,25 @@
 
 pub use winit::os::android::{WindowBuilderExt, WindowExt};
 
-pub use api::egl::ffi::egl::types::EGLContext;
+pub use api::egl::ffi::EGLContext;
+
+use {Context, HeadlessContext};
+use os::GlContextExt;
+
+impl GlContextExt for Context {
+    type Handle = EGLContext;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
+}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = EGLContext;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
+}

--- a/src/os/android.rs
+++ b/src/os/android.rs
@@ -1,3 +1,5 @@
 #![cfg(any(target_os = "android"))]
 
 pub use winit::os::android::{WindowBuilderExt, WindowExt};
+
+pub use api::egl::ffi::egl::types::EGLContext;

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -1,5 +1,6 @@
 #![cfg(target_os = "macos")]
 
+pub use cocoa::base::id;
 pub use winit::os::macos::ActivationPolicy;
 pub use winit::os::macos::MonitorIdExt;
 pub use winit::os::macos::WindowBuilderExt;

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -5,3 +5,24 @@ pub use winit::os::macos::ActivationPolicy;
 pub use winit::os::macos::MonitorIdExt;
 pub use winit::os::macos::WindowBuilderExt;
 pub use winit::os::macos::WindowExt;
+
+use {Context, HeadlessContext};
+use os::GlContextExt;
+
+impl GlContextExt for Context {
+    type Handle = id;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
+}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = id;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
+}

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -1,6 +1,5 @@
 #![cfg(target_os = "macos")]
 
-pub use cocoa::base::id;
 pub use winit::os::macos::ActivationPolicy;
 pub use winit::os::macos::MonitorIdExt;
 pub use winit::os::macos::WindowBuilderExt;
@@ -9,8 +8,10 @@ pub use winit::os::macos::WindowExt;
 use {Context, HeadlessContext};
 use os::GlContextExt;
 
+use std::os::raw::c_void;
+
 impl GlContextExt for Context {
-    type Handle = id;
+    type Handle = *mut c_void;
 
     #[inline]
     unsafe fn raw_handle(&self) -> Self::Handle {
@@ -19,7 +20,7 @@ impl GlContextExt for Context {
 }
 
 impl GlContextExt for HeadlessContext {
-    type Handle = id;
+    type Handle = *mut c_void;
 
     #[inline]
     unsafe fn raw_handle(&self) -> Self::Handle {

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -19,5 +19,5 @@ pub trait GlContextExt {
     type Handle;
 
     /// Returns the raw context handle.
-    unsafe fn as_mut_ptr(&self) -> Self::Handle;
+    unsafe fn raw_handle(&self) -> Self::Handle;
 }

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,12 +1,23 @@
 //! Contains traits with platform-specific methods in them.
 //!
-//! Contains the follow modules:
+//! Contains the following modules:
 //!
+//!  - `android`
 //!  - `macos`
 //!  - `unix`
 //!  - `windows`
 //!
+
 pub mod android;
 pub mod macos;
 pub mod unix;
 pub mod windows;
+
+/// Platform-specific extensions for OpenGL contexts.
+pub trait GlContextExt {
+    /// Raw context handle.
+    type Handle;
+
+    /// Returns the raw context handle.
+    unsafe fn as_mut_ptr(&self) -> Self::Handle;
+}

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -5,3 +5,14 @@ pub use winit::os::unix::EventsLoopExt;
 pub use winit::os::unix::MonitorIdExt;
 pub use winit::os::unix::WindowBuilderExt;
 pub use winit::os::unix::WindowExt;
+
+pub use api::egl::ffi::egl::types::EGLContext;
+pub use api::glx::ffi::GLXContext;
+pub use api::osmesa::ffi::OSMesaContext;
+
+/// Context types available on Unix-like platforms.
+#[derive(Clone, Debug)]
+pub enum Context {
+    Glx(GLXContext),
+    Egl(EGLContext),
+}

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -6,13 +6,28 @@ pub use winit::os::unix::MonitorIdExt;
 pub use winit::os::unix::WindowBuilderExt;
 pub use winit::os::unix::WindowExt;
 
-pub use api::egl::ffi::egl::types::EGLContext;
+pub use api::egl::ffi::EGLContext;
 pub use api::glx::ffi::GLXContext;
 pub use api::osmesa::ffi::OSMesaContext;
+pub use platform::RawHandle;
 
-/// Context types available on Unix-like platforms.
-#[derive(Clone, Debug)]
-pub enum Context {
-    Glx(GLXContext),
-    Egl(EGLContext),
+use {Context, HeadlessContext};
+use os::GlContextExt;
+
+impl GlContextExt for Context {
+    type Handle = RawHandle;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
+}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = OSMesaContext;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
 }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,18 +1,19 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
+pub use api::egl::ffi::EGLContext;
+pub use api::glx::ffi::GLXContext;
+pub use platform::RawHandle;
+
 pub use winit::os::unix::XNotSupported;
 pub use winit::os::unix::EventsLoopExt;
 pub use winit::os::unix::MonitorIdExt;
 pub use winit::os::unix::WindowBuilderExt;
 pub use winit::os::unix::WindowExt;
 
-pub use api::egl::ffi::EGLContext;
-pub use api::glx::ffi::GLXContext;
-pub use api::osmesa::ffi::OSMesaContext;
-pub use platform::RawHandle;
-
 use {Context, HeadlessContext};
 use os::GlContextExt;
+
+use std::os::raw::c_void;
 
 impl GlContextExt for Context {
     type Handle = RawHandle;
@@ -24,7 +25,7 @@ impl GlContextExt for Context {
 }
 
 impl GlContextExt for HeadlessContext {
-    type Handle = OSMesaContext;
+    type Handle = *mut c_void;
 
     #[inline]
     unsafe fn raw_handle(&self) -> Self::Handle {

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "windows")]
 
-pub use winapi::HDC;
+pub use winapi::HGLRC;
 pub use winit::os::windows::{WindowBuilderExt, WindowExt, MonitorIdExt};
 
 pub use api::egl::ffi::EGLContext;

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -3,11 +3,26 @@
 pub use winapi::HDC;
 pub use winit::os::windows::{WindowBuilderExt, WindowExt, MonitorIdExt};
 
-pub use api::egl::ffi::egl::types::EGLContext;
+pub use api::egl::ffi::EGLContext;
+pub use platform::RawHandle;
 
-/// Context types available on Windows.
-#[derive(Clone, Debug)]
-pub enum Context {
-    Egl(EGLContext),
-    Wgl(HDC),
+use {Context, HeadlessContext};
+use os::GlContextExt;
+
+impl GlContextExt for Context {
+    type Handle = RawHandle;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
+}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = RawHandle;
+
+    #[inline]
+    unsafe fn raw_handle(&self) -> Self::Handle {
+        self.context.raw_handle()
+    }
 }

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,3 +1,13 @@
 #![cfg(target_os = "windows")]
 
+pub use winapi::HDC;
 pub use winit::os::windows::{WindowBuilderExt, WindowExt, MonitorIdExt};
+
+pub use api::egl::ffi::egl::types::EGLContext;
+
+/// Context types available on Windows.
+#[derive(Clone, Debug)]
+pub enum Context {
+    Egl(EGLContext),
+    Wgl(HDC),
+}

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -3,4 +3,3 @@
 pub use winit::EventsLoop;
 
 pub use api::android::*;
-pub use api::egl::ffi::egl::types::EGLContext;

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -3,3 +3,4 @@
 pub use winit::EventsLoop;
 
 pub use api::android::*;
+pub use api::egl::ffi::egl::types::EGLContext;

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -1,11 +1,10 @@
 #![cfg(target_os = "emscripten")]
 
+use std::ffi::CString;
+
 use {Api, ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements};
-use os::GlContextExt;
 
 use winit;
-
-use std::ffi::CString;
 
 mod ffi;
 
@@ -117,13 +116,9 @@ impl Context {
             srgb: true,
         }
     }
-}
-
-impl GlContextExt for Context {
-    type Handle = ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE;
 
     #[inline]
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+    pub unsafe fn raw_handle(&self) -> ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE {
         self.context
     }
 }
@@ -190,13 +185,9 @@ impl HeadlessContext {
     pub fn get_pixel_format(&self) -> PixelFormat {
         unimplemented!()
     }
-}
-
-impl GlContextExt for HeadlessContext {
-    type Handle = ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE;
 
     #[inline]
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+    pub unsafe fn raw_handle(&self) -> ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE {
         self.context
     }
 }

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -1,7 +1,10 @@
 #![cfg(target_os = "emscripten")]
 
 use {Api, ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements};
+use os::GlContextExt;
+
 use winit;
+
 use std::ffi::CString;
 
 mod ffi;
@@ -116,6 +119,15 @@ impl Context {
     }
 }
 
+impl GlContextExt for Context {
+    type Handle = ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE;
+
+    #[inline]
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.context
+    }
+}
+
 impl Drop for Context {
     fn drop(&mut self) {
         unsafe {
@@ -177,6 +189,15 @@ impl HeadlessContext {
     #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         unimplemented!()
+    }
+}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = ffi::EMSCRIPTEN_WEBGL_CONTEXT_HANDLE;
+
+    #[inline]
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.context
     }
 }
 

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -1,12 +1,24 @@
 #![cfg(target_os = "ios")]
 
+pub use api::ios::*;
+
+pub use cocoa::base::id;
+
 use GlAttributes;
 use CreationError;
 use PixelFormat;
 use PixelFormatRequirements;
 use ContextError;
+use os::GlContextExt;
 
-pub use api::ios::*;
+impl GlContextExt for Context {
+    type Handle = id;
+
+    #[inline]
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        *self.eagl_context.deref()
+    }
+}
 
 #[derive(Clone, Default)]
 pub struct PlatformSpecificHeadlessBuilderAttributes;
@@ -46,9 +58,17 @@ impl HeadlessContext {
     }
 
     pub fn get_pixel_format(&self) -> PixelFormat {
-        unimplemented!();
+        unimplemented!()
     }
 }
 
 unsafe impl Send for HeadlessContext {}
 unsafe impl Sync for HeadlessContext {}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = i32;
+
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        unimplemented!()
+    }
+}

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -120,7 +120,7 @@ impl Context {
                 GlContext::Glx(ref ctxt) => RawHandle::Glx(ctxt.raw_handle()),
                 GlContext::Egl(ref ctxt) => RawHandle::Egl(ctxt.raw_handle()),
                 GlContext::None => panic!()
-            }
+            },
             Context::Wayland(ref ctxt) => RawHandle::Egl(ctxt.raw_handle())
         }
     }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,13 +1,15 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 
-use winit;
-use winit::os::unix::EventsLoopExt;
-
 use {Api, ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements};
 use api::egl;
 use api::glx;
-use api::osmesa::{self, OsMesaContext};
+use api::osmesa::OsMesaContext;
 use self::x11::GlContext;
+
+use winit;
+use winit::os::unix::EventsLoopExt;
+
+use std::os::raw::c_void;
 
 mod wayland;
 mod x11;
@@ -179,7 +181,7 @@ impl HeadlessContext {
     }
 
     #[inline]
-    pub unsafe fn raw_handle(&self) -> osmesa::ffi::OSMesaContext {
+    pub unsafe fn raw_handle(&self) -> *mut c_void {
         self.0.raw_handle()
     }
 }

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -4,8 +4,7 @@ use winit;
 use winit::os::unix::WindowExt;
 use {ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements};
 use api::dlopen;
-use api::egl::{self, Context as EglContext};
-use api::egl::ffi;
+use api::egl::{self, ffi, Context as EglContext};
 use wayland_client::egl as wegl;
 
 pub struct Context {
@@ -81,7 +80,7 @@ impl Context {
     }
 
     #[inline]
-    pub unsafe fn as_mut_ptr(&self) -> ffi::egl::types::EGLContext {
-        self.context.as_mut_ptr()
+    pub unsafe fn raw_handle(&self) -> ffi::EGLContext {
+        self.context.raw_handle()
     }
 }

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -4,8 +4,8 @@ use winit;
 use winit::os::unix::WindowExt;
 use {ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements};
 use api::dlopen;
-use api::egl;
-use api::egl::Context as EglContext;
+use api::egl::{self, Context as EglContext};
+use api::egl::ffi;
 use wayland_client::egl as wegl;
 
 pub struct Context {
@@ -78,5 +78,10 @@ impl Context {
     #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.context.get_pixel_format().clone()
+    }
+
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> ffi::egl::types::EGLContext {
+        self.context.as_mut_ptr()
     }
 }

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -15,6 +15,7 @@ use api::{dlopen, egl};
 use api::egl::Context as EglContext;
 use api::glx::ffi::glx::Glx;
 use api::egl::ffi::egl::Egl;
+use os::unix::Context as OsContext;
 
 #[derive(Debug)]
 struct NoX11Connection;
@@ -293,6 +294,15 @@ impl Context {
         match self.context {
             GlContext::Glx(ref ctxt) => ctxt.get_pixel_format(),
             GlContext::Egl(ref ctxt) => ctxt.get_pixel_format(),
+            GlContext::None => panic!()
+        }
+    }
+
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> OsContext {
+        match self.context {
+            GlContext::Glx(ref ctxt) => OsContext::Glx(ctxt.as_mut_ptr()),
+            GlContext::Egl(ref ctxt) => OsContext::Egl(ctxt.as_mut_ptr()),
             GlContext::None => panic!()
         }
     }

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -15,7 +15,6 @@ use api::{dlopen, egl};
 use api::egl::Context as EglContext;
 use api::glx::ffi::glx::Glx;
 use api::egl::ffi::egl::Egl;
-use os::unix::Context as OsContext;
 
 #[derive(Debug)]
 struct NoX11Connection;
@@ -84,7 +83,7 @@ impl GlxOrEgl {
     }
 }
 
-enum GlContext {
+pub enum GlContext {
     Glx(GlxContext),
     Egl(EglContext),
     None,
@@ -299,11 +298,7 @@ impl Context {
     }
 
     #[inline]
-    pub unsafe fn as_mut_ptr(&self) -> OsContext {
-        match self.context {
-            GlContext::Glx(ref ctxt) => OsContext::Glx(ctxt.as_mut_ptr()),
-            GlContext::Egl(ref ctxt) => OsContext::Egl(ctxt.as_mut_ptr()),
-            GlContext::None => panic!()
-        }
+    pub unsafe fn raw_handle(&self) -> &GlContext {
+        &self.context
     }
 }

--- a/src/platform/macos/headless.rs
+++ b/src/platform/macos/headless.rs
@@ -2,15 +2,16 @@ use ContextError;
 use CreationError;
 use CreationError::OsError;
 use GlAttributes;
+use PixelFormat;
 use PixelFormatRequirements;
+use super::helpers;
 
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
 use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
 use cocoa::base::{id, nil};
 use cocoa::appkit::*;
-use PixelFormat;
-use super::helpers;
+use std::os::raw::c_void;
 
 #[derive(Clone, Default)]
 pub struct PlatformSpecificHeadlessBuilderAttributes;
@@ -87,8 +88,8 @@ impl HeadlessContext {
     }
 
     #[inline]
-    pub unsafe fn raw_handle(&self) -> id {
-        self.context
+    pub unsafe fn raw_handle(&self) -> *mut c_void {
+        self.context as *mut _
     }
 }
 

--- a/src/platform/macos/headless.rs
+++ b/src/platform/macos/headless.rs
@@ -12,8 +12,6 @@ use cocoa::appkit::*;
 use PixelFormat;
 use super::helpers;
 
-use os::GlContextExt;
-
 #[derive(Clone, Default)]
 pub struct PlatformSpecificHeadlessBuilderAttributes;
 
@@ -87,15 +85,12 @@ impl HeadlessContext {
     pub fn get_pixel_format(&self) -> PixelFormat {
         unimplemented!();
     }
+
+    #[inline]
+    pub unsafe fn raw_handle(&self) -> id {
+        self.context
+    }
 }
 
 unsafe impl Send for HeadlessContext {}
 unsafe impl Sync for HeadlessContext {}
-
-impl GlContextExt for HeadlessContext {
-    type Handle = id;
-
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
-        self.context
-    }
-}

--- a/src/platform/macos/headless.rs
+++ b/src/platform/macos/headless.rs
@@ -12,6 +12,8 @@ use cocoa::appkit::*;
 use PixelFormat;
 use super::helpers;
 
+use os::GlContextExt;
+
 #[derive(Clone, Default)]
 pub struct PlatformSpecificHeadlessBuilderAttributes;
 
@@ -89,3 +91,11 @@ impl HeadlessContext {
 
 unsafe impl Send for HeadlessContext {}
 unsafe impl Sync for HeadlessContext {}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = id;
+
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.context
+    }
+}

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -2,7 +2,8 @@
 
 pub use self::headless::HeadlessContext;
 pub use self::headless::PlatformSpecificHeadlessBuilderAttributes;
-pub use winit::{MonitorId};
+
+pub use winit::MonitorId;
 
 use CreationError;
 use ContextError;
@@ -11,23 +12,20 @@ use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
 
-use objc::runtime::{BOOL, NO};
-
 use cgl::{CGLEnable, kCGLCECrashOnRemovedFunctions, CGLSetParameter, kCGLCPSurfaceOpacity};
-
 use cocoa::base::{id, nil};
 use cocoa::foundation::NSAutoreleasePool;
 use cocoa::appkit::{self, NSOpenGLContext, NSOpenGLPixelFormat};
-
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
 use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
+use objc::runtime::{BOOL, NO};
+use winit;
+use winit::os::macos::WindowExt;
 
 use std::str::FromStr;
 use std::ops::Deref;
-
-use winit;
-use winit::os::macos::WindowExt;
+use std::os::raw::c_void;
 
 mod headless;
 mod helpers;
@@ -39,7 +37,6 @@ pub struct Context {
 }
 
 impl Context {
-
     pub fn new(
         window_builder: winit::WindowBuilder,
         events_loop: &winit::EventsLoop,
@@ -185,8 +182,8 @@ impl Context {
     }
 
     #[inline]
-    pub unsafe fn raw_handle(&self) -> id {
-        *self.gl.deref()
+    pub unsafe fn raw_handle(&self) -> *mut c_void {
+        *self.gl.deref() as *mut _
     }
 }
 

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -10,7 +10,6 @@ use GlAttributes;
 use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
-use os::GlContextExt;
 
 use objc::runtime::{BOOL, NO};
 
@@ -184,13 +183,9 @@ impl Context {
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
     }
-}
-
-impl GlContextExt for Context {
-    type Handle = id;
 
     #[inline]
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+    pub unsafe fn raw_handle(&self) -> id {
         *self.gl.deref()
     }
 }

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -1,11 +1,16 @@
 #![cfg(target_os = "macos")]
 
+pub use self::headless::HeadlessContext;
+pub use self::headless::PlatformSpecificHeadlessBuilderAttributes;
+pub use winit::{MonitorId};
+
 use CreationError;
 use ContextError;
 use GlAttributes;
 use PixelFormat;
 use PixelFormatRequirements;
 use Robustness;
+use os::GlContextExt;
 
 use objc::runtime::{BOOL, NO};
 
@@ -24,9 +29,6 @@ use std::ops::Deref;
 
 use winit;
 use winit::os::macos::WindowExt;
-pub use winit::{MonitorId};
-pub use self::headless::HeadlessContext;
-pub use self::headless::PlatformSpecificHeadlessBuilderAttributes;
 
 mod headless;
 mod helpers;
@@ -181,6 +183,15 @@ impl Context {
     #[inline]
     pub fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
+    }
+}
+
+impl GlContextExt for Context {
+    type Handle = id;
+
+    #[inline]
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        *self.gl.deref()
     }
 }
 

--- a/src/platform/windows/context.rs
+++ b/src/platform/windows/context.rs
@@ -128,7 +128,7 @@ impl Context {
     #[inline]
     pub unsafe fn raw_handle(&self) -> RawHandle {
         match *self {
-            Context::Wgl(ref c) => RawHandle::Wgl(c.raw_handle()),
+            Context::Wgl(ref c) => RawHandle::Wgl(c.get_hglrc()),
             Context::Egl(ref c) => RawHandle::Egl(c.raw_handle()),
         }
     }

--- a/src/platform/windows/context.rs
+++ b/src/platform/windows/context.rs
@@ -2,6 +2,7 @@
 
 use std::ptr;
 
+use winapi;
 use winit;
 
 use ContextError;
@@ -12,13 +13,11 @@ use Api;
 use PixelFormat;
 use PixelFormatRequirements;
 
-use winapi;
-
 use api::wgl::Context as WglContext;
 use api::egl::Context as EglContext;
 use api::egl::ffi::egl::Egl;
 use api::egl;
-use os::windows::Context as OsContext;
+use platform::RawHandle;
 
 unsafe impl Send for Context {}
 unsafe impl Sync for Context {}
@@ -127,10 +126,10 @@ impl Context {
     }
 
     #[inline]
-    pub unsafe fn as_mut_ptr(&self) -> OsContext {
+    pub unsafe fn raw_handle(&self) -> RawHandle {
         match *self {
-            Context::Wgl(ref c) => OsContext::Wgl(c.as_mut_ptr()),
-            Context::Egl(ref c) => OsContext::Egl(c.as_mut_ptr()),
+            Context::Wgl(ref c) => RawHandle::Wgl(c.raw_handle()),
+            Context::Egl(ref c) => RawHandle::Egl(c.raw_handle()),
         }
     }
 }

--- a/src/platform/windows/context.rs
+++ b/src/platform/windows/context.rs
@@ -18,6 +18,7 @@ use api::wgl::Context as WglContext;
 use api::egl::Context as EglContext;
 use api::egl::ffi::egl::Egl;
 use api::egl;
+use os::windows::Context as OsContext;
 
 unsafe impl Send for Context {}
 unsafe impl Sync for Context {}
@@ -27,9 +28,7 @@ pub enum Context {
     Wgl(WglContext),
 }
 
-
 impl Context {
-
     /// See the docs in the crate root file.
     pub fn new(
         window_builder: winit::WindowBuilder,
@@ -124,6 +123,14 @@ impl Context {
         match *self {
             Context::Wgl(ref c) => c.get_pixel_format(),
             Context::Egl(ref c) => c.get_pixel_format(),
+        }
+    }
+
+    #[inline]
+    pub unsafe fn as_mut_ptr(&self) -> OsContext {
+        match *self {
+            Context::Wgl(ref c) => OsContext::Wgl(c.as_mut_ptr()),
+            Context::Egl(ref c) => OsContext::Egl(c.as_mut_ptr()),
         }
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -12,6 +12,8 @@ use winit;
 use api::egl::ffi::egl::Egl;
 use api::egl;
 use api::egl::Context as EglContext;
+use os::GlContextExt;
+use os::windows::Context as OsContext;
 
 use std::ffi::CString;
 use std::ops::{Deref, DerefMut};
@@ -89,6 +91,14 @@ impl DerefMut for Context {
     #[inline]
     fn deref_mut(&mut self) -> &mut context::Context {
         &mut self.0
+    }
+}
+
+impl GlContextExt for Context {
+    type Handle = OsContext;
+
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        self.0.as_mut_ptr()
     }
 }
 
@@ -173,6 +183,17 @@ impl HeadlessContext {
         match self {
             &HeadlessContext::HiddenWindow(_, _, ref ctxt) => ctxt.get_pixel_format(),
             &HeadlessContext::EglPbuffer(ref ctxt) => ctxt.get_pixel_format(),
+        }
+    }
+}
+
+impl GlContextExt for HeadlessContext {
+    type Handle = OsContext;
+
+    unsafe fn as_mut_ptr(&self) -> Self::Handle {
+        match *self {
+            HeadlessContext::HiddenWindow(_, _, ref ctxt) => ctxt.as_mut_ptr(),
+            HeadlessContext::EglPbuffer(ref ctxt) => OsContext::Egl(ctxt.as_mut_ptr()),
         }
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -24,7 +24,7 @@ mod context;
 #[derive(Clone, Debug)]
 pub enum RawHandle {
     Egl(egl::ffi::EGLContext),
-    Wgl(winapi::HDC),
+    Wgl(winapi::HGLRC),
 }
 
 /// Stupid wrapper because `*const libc::c_void` doesn't implement `Sync`.


### PR DESCRIPTION
### Added

* Add `GlContextExt` trait, which grants type-safe access to the underlying OpenGL context (fixes #935).

### Fixed

* Minor formatting changes, i.e. fixing some spacing, reordering imports, etc.
* Fix small doc comment typo.

CC @tomaka @kvark 