### PR TITLE
Update as_mut_ptr to raw_handle and remove GlContextExt from iOS

### DIFF
--- a/src/api/ios/mod.rs
+++ b/src/api/ios/mod.rs
@@ -63,10 +63,8 @@
 #![deny(warnings)]
 
 use std::collections::VecDeque;
-use std::ptr;
-use std::io;
-use std::mem;
 use std::ffi::CString;
+use std::{mem, io, os, ptr};
 
 use libc;
 use objc::runtime::{Class, BOOL, YES, NO };
@@ -366,6 +364,11 @@ impl Window {
     #[inline]
     pub fn create_window_proxy(&self) -> WindowProxy {
         WindowProxy
+    }
+
+    #[inline]
+    pub unsafe fn raw_handle(&self) -> *mut os::raw::c_void {
+        self.eagl_context as *mut _
     }
 }
 

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -9,16 +9,8 @@ use CreationError;
 use PixelFormat;
 use PixelFormatRequirements;
 use ContextError;
-use os::GlContextExt;
 
-impl GlContextExt for Context {
-    type Handle = id;
-
-    #[inline]
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
-        *self.eagl_context.deref()
-    }
-}
+use std::os::raw::c_void;
 
 #[derive(Clone, Default)]
 pub struct PlatformSpecificHeadlessBuilderAttributes;
@@ -60,15 +52,11 @@ impl HeadlessContext {
     pub fn get_pixel_format(&self) -> PixelFormat {
         unimplemented!()
     }
+
+    pub unsafe fn raw_handle(&self) -> *mut c_void {
+        unimplemented!()
+    }
 }
 
 unsafe impl Send for HeadlessContext {}
 unsafe impl Sync for HeadlessContext {}
-
-impl GlContextExt for HeadlessContext {
-    type Handle = i32;
-
-    unsafe fn as_mut_ptr(&self) -> Self::Handle {
-        unimplemented!()
-    }
-}


### PR DESCRIPTION
### Fixed

* Replace references to `as_mut_ptr()` to `raw_handle()` in `{api,platform}::ios`.
* Eliminate usage of `GlContextExt` from `{api,platform}::ios`.

### Changed

* Change `raw_handle()` to return `*mut std::os::raw::c_void` on iOS instead of a raw Cocoa `id`.
* Reorder imports in `api::ios` to be a little more compact.

Follow up to #939, CC @tomaka