### PR TITLE
Update gl_generator (fixes broken build)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ shared_library = "0.1.0"
 winit = "0.8.1"
 
 [build-dependencies]
-gl_generator = "0.5"
+gl_generator = "0.6"
 
 [target.'cfg(target_os = "android")'.dependencies.android_glue]
 version = "0.2"


### PR DESCRIPTION
Building with gl_generator 0.5.5 fails with
```
thread 'main' panicked at 'Type conversion not implemented for `EGLDEBUGPROCKHR`', /home/bobo1239/.cargo/registry/src/github.com-1ecc6299db9ec823/gl_generator-0.5.5/registry/parse.rs
:979:13
```
so best to publish this asap.