### PR TITLE
Fixed warnings on Mac when building example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
 #[macro_use]
 extern crate lazy_static;
 
+// Caca requires shared_library macro_use on Linux
+#[cfg(target_os = "linux")]
 #[macro_use]
 extern crate shared_library;
 

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -135,10 +135,12 @@ impl Context {
 
     #[inline]
     pub fn is_current(&self) -> bool {
+        let res;
+
         unsafe {
             let pool = NSAutoreleasePool::new(nil);
             let current = NSOpenGLContext::currentContext(nil);
-            let mut res = false;
+            
             if current != nil {
                 let is_equal: BOOL = msg_send![current, isEqual:*self.gl];
                 res = is_equal != NO
@@ -146,8 +148,9 @@ impl Context {
                 res = false
             }
             let _: () = msg_send![pool, release];
-            res
         }
+
+        res
     }
 
     pub fn get_proc_address(&self, addr: &str) -> *const () {


### PR DESCRIPTION
Repro using example from "Try it!" section on front page:
cargo run --example window

Warnings were:
warning: unused `#[macro_use]` import
  --> src/lib.rs:38:1
   |
38 | #[macro_use]
   | ^^^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default

warning: value assigned to `res` is never read
   --> src/platform/macos/mod.rs:141:17
    |
141 |             let mut res = false;
    |                 ^^^^^^^
    |
    = note: #[warn(unused_assignments)] on by default