### PR TITLE
Bump gl_generator to new version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ shared_library = "0.1.0"
 winit = "0.8.1"
 
 [build-dependencies]
-gl_generator = "0.6"
+gl_generator = "0.7"
 
 [target.'cfg(target_os = "android")'.dependencies.android_glue]
 version = "0.2"


### PR DESCRIPTION
This is needed for getting glutin to work when using rustc nightly on release mode on windows.