### PR TITLE
[macos] select compatibility profile if gl version is low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Unreleased
-- Add support for winapi 0.3
-
+- Add support for winapi 0.3 ([#975](https://github.com/tomaka/glutin/pull/975))
+- Fix MacOS to return compatibility profile if applicable (#[977](https://github.com/tomaka/glutin/pull/977))

--- a/src/platform/macos/helpers.rs
+++ b/src/platform/macos/helpers.rs
@@ -24,7 +24,11 @@ pub fn get_gl_profile<T>(
     } else if let Some(v) = version {
         // second, process exact requested version, if any
         if v < (3, 2) {
-            Err(CreationError::OpenGlVersionNotSupported)
+            if opengl.profile.is_none() && v <= (2, 1) {
+                Ok(NSOpenGLProfileVersionLegacy)
+            } else {
+                Err(CreationError::OpenGlVersionNotSupported)
+            }
         } else if v == (3, 2) {
             Ok(NSOpenGLProfileVersion3_2Core)
         } else {


### PR DESCRIPTION
This is a hotfix to #963

When the user (@ozkriff in this case... Ohai!) is not explicit about the profile they need, the code doesn't consider compatibility profile, but it should.
~~Also contains a version bump for supposed publishing. Not sure how you track release branches/versions? I don't see either branches or tags for latest releases.~~

r? @tomaka 
  