### PR TITLE
Bump dependencies to fix macOS build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 lazy_static = "1"
 libc = "0.2"
 shared_library = "0.1.0"
-winit = "0.10.1"
+winit = "0.11.0"
 
 [build-dependencies]
 gl_generator = "0.8"
@@ -44,4 +44,4 @@ features = [
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
 osmesa-sys = "0.1.0"
 wayland-client = { version = "0.12", features = ["egl", "dlopen"] }
-x11-dl = "2.8"
+x11-dl = "2.17"


### PR DESCRIPTION
Running `cargo test` failed on macOS with these messages:
```
error: no matching version `^0.10.1` found for package `winit` (required by `glutin`)
location searched: registry `https://github.com/rust-lang/crates.io-index`
versions found: 0.11.0, 0.10.0, 0.9.0, ...
```
```
error: failed to select a version for `x11-dl` (required by `winit`):
all possible versions conflict with previously selected versions of `x11-dl`
  version 2.14.0 in use by x11-dl v2.14.0
  possible versions to select: 2.17.2, 2.17.1, 2.17.0
```
(The latter one is a bit strange - works on Linux, but fails on macOS, where X11 is not required...?)