### PR TITLE
Make the `pf_reqs` field of `ContextBuilder` public.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub struct ContextBuilder<'a> {
     /// The attributes to use to create the context.
     pub gl_attr: GlAttributes<&'a Context>,
     // Should be made public once it's stabilized.
-    pf_reqs: PixelFormatRequirements,
+    pub pf_reqs: PixelFormatRequirements,
 }
 
 /// Represents an OpenGL context and a Window with which it is associated.


### PR DESCRIPTION
Its type `PixelFormatRequirements` is already public with public fields.