### PR TITLE
egl: Don't panic if egl returns a BAD_MATCH error.

### DIFF
--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -771,6 +771,7 @@ unsafe fn create_context(egl: &ffi::egl::Egl, display: ffi::egl::types::EGLDispl
 
     if context.is_null() {
         match egl.GetError() as u32 {
+            ffi::egl::BAD_MATCH |
             ffi::egl::BAD_ATTRIBUTE => return Err(CreationError::OpenGlVersionNotSupported),
             e => panic!("eglCreateContext failed: 0x{:x}", e),
         }


### PR DESCRIPTION
This is what happens on my pretty-standard system when the GL version is not
supported, and it's not pretty.