### PR TITLE
Update to version 0.12 of winit. Publish 0.14.0. Update CHANGELOG. Address deprecation warning in wayland backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# Version 0.14.0 (2018-04-06)
+
+- Update winit dependency to 0.12.0
+- Update wayland backend to not use deprecated `get_inner_size_points` method.
+
 # Version 0.13.1 (2018-03-07)
 
 - Fix android activity life cycle

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glutin"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]
@@ -14,7 +14,7 @@ build = "build.rs"
 lazy_static = "1"
 libc = "0.2"
 shared_library = "0.1.0"
-winit = "0.11.2"
+winit = "0.12.0"
 
 [build-dependencies]
 gl_generator = "0.9"

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -21,7 +21,10 @@ impl Context {
     ) -> Result<(winit::Window, Self), CreationError>
     {
         let window = try!(window_builder.build(events_loop));
-        let (w, h) = window.get_inner_size_points().unwrap();
+        let (w_px, h_px) = window.get_inner_size().unwrap();
+        let hidpi_factor = window.hidpi_factor();
+        let w = (w_px as f32 / hidpi_factor) as u32;
+        let h = (h_px as f32 / hidpi_factor) as u32;
         let surface = window.get_wayland_surface().unwrap();
         let egl_surface = unsafe { wegl::WlEglSurface::new_from_raw(surface as *mut _, w as i32, h as i32) };
         let context = {


### PR DESCRIPTION
This also updates the wayland backend to not use deprecated
`get_inner_size_points` method and instead calculate the points from the
`get_inner_size` and `hidpi_factor` methods.