### PR TITLE
Use HTTPS Heroku badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # glutin -  OpenGL, UTilities and INput
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tomaka/glutin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![](http://meritbadge.herokuapp.com/glutin)](https://crates.io/crates/glutin)
+[![](https://meritbadge.herokuapp.com/glutin)](https://crates.io/crates/glutin)
 
 [![Docs.rs](https://docs.rs/glutin/badge.svg)](https://docs.rs/glutin)
 


### PR DESCRIPTION
The http access causes a mixed-content warning when visiting https://crates.io/crates/glutin