### PR TITLE
[Do Not Merge] Use EGL for Linux headless contexts

### DIFF
--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -31,13 +31,13 @@ impl fmt::Display for NoX11Connection {
     }
 }
 
-struct GlxOrEgl {
-    glx: Option<Glx>,
-    egl: Option<Egl>,
+pub(super) struct GlxOrEgl {
+    pub glx: Option<Glx>,
+    pub egl: Option<Egl>,
 }
 
 impl GlxOrEgl {
-    fn new() -> GlxOrEgl {
+    pub(super) fn new() -> GlxOrEgl {
         // TODO: use something safer than raw "dlopen"
         let glx = {
             let mut libglx = unsafe {


### PR DESCRIPTION
OsMesa isn't the only way to make headless contexts on Linux. It would be nice to also support EGL headless contexts. This PR sketches out how to accomplish this. It is functional (on my Ubuntu machine...) but lacks some relevant error handling and any logic to select whether to use EGL or OsMesa.

This would resolve #505 