### PR TITLE
Fix gpu switching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,24 @@ impl<'a> ContextBuilder<'a> {
         self.pf_reqs.srgb = srgb_enabled;
         self
     }
+    
+    /// Sets whether double buffering should be enabled
+    ///
+    /// The default value is `None`.
+    #[inline]
+    pub fn with_double_buffer(mut self, enabled: Option<bool>) -> Self {
+        self.pf_reqs.double_buffer = enabled;
+        self
+    }
+    
+    /// Sets whether hardware acceleration is required
+    ///
+    /// The default value is `Some(true)`
+    #[inline]
+    pub fn with_hw_accel(mut self, enabled: Option<bool>) -> Self {
+        self.pf_reqs.hardware_accelerated = enabled;
+        self
+    }
 }
 
 impl GlWindow {

--- a/src/platform/macos/headless.rs
+++ b/src/platform/macos/headless.rs
@@ -26,7 +26,7 @@ impl HeadlessContext {
                _: &PlatformSpecificHeadlessBuilderAttributes)
                -> Result<HeadlessContext, CreationError>
     {
-        let gl_profile = helpers::get_gl_profile(opengl)?;
+        let gl_profile = helpers::get_gl_profile(opengl, pf_reqs)?;
         let attributes = helpers::build_nsattributes(pf_reqs, gl_profile)?;
         let context = unsafe {
             let pixelformat = NSOpenGLPixelFormat::alloc(nil).initWithAttributes_(&attributes);

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -61,7 +61,7 @@ impl Context {
 
         let view = window.get_nsview() as id;
 
-        let gl_profile = helpers::get_gl_profile(gl_attr)?;
+        let gl_profile = helpers::get_gl_profile(gl_attr, pf_reqs)?;
         let attributes = helpers::build_nsattributes(pf_reqs, gl_profile)?;
         unsafe {
             let pixel_format = IdRef::new(NSOpenGLPixelFormat::alloc(nil)


### PR DESCRIPTION
Fixes #980

This PR contains 2 things. First users of the ContextBuilder can now specify hw accel and double buffering whereas before they were defaulted and couldn't be altered in this manner. Secondly on macOS when probing to determine the latest GL version we now take into account any requested attributes from the PixelFormatRequirements. This is to prevent forcing using a discrete GPU on macs when its not actually needed/desired.

Note: The addition of NSOpenGLPFAAllowOfflineRenderers is required for automatic graphics switching to work and the main build_nsattributes already always includes this attribute. In my testing of glutin via gfx-rs this attribute will not prevent an application from using the discrete gpu but rather just enable the switching if applicable.