### PR TITLE
Work around an Android emulator bug(?)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Fix regression that prevented automatic graphics switching in MacOS ([#980](https://github.com/tomaka/glutin/issues/980))
 - Add `ContextBuilder::with_double_buffer` function
 - Add `ContextBuilder::with_hardware_acceleration` function
+- Work around a presumed bug Android emulator bug
+  that would cause context creation to return `CreationError::OpenGlVersionNotSupported`
+  in some configurations
+  ([1036](https://github.com/tomaka/glutin/pull/1036))
 
 # Version 0.16.0 (2018-05-09)
 

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -748,8 +748,13 @@ unsafe fn create_context(egl: &ffi::egl::Egl, display: ffi::egl::types::EGLDispl
             //flags = flags | ffi::egl::CONTEXT_OPENGL_DEBUG_BIT_KHR as i32;
         }
 
-        context_attributes.push(ffi::egl::CONTEXT_FLAGS_KHR as i32);
-        context_attributes.push(flags);
+        // In at least some configurations, the Android emulator’s GL implementation
+        // advertises support for the EGL_KHR_create_context extension
+        // but returns BAD_ATTRIBUTE when CONTEXT_FLAGS_KHR is used.
+        if flags != 0 {
+            context_attributes.push(ffi::egl::CONTEXT_FLAGS_KHR as i32);
+            context_attributes.push(flags);
+        }
 
     } else if egl_version >= &(1, 3) && api == Api::OpenGlEs {
         // robustness is not supported


### PR DESCRIPTION
Do not pass a `CONTEXT_FLAGS_KHR` attribute to `egl.CreateContext` when it is at the default value.