### PR TITLE
glX: Improve error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- **Breaking:** Added `OsError` variant to `ContextError`.
+- Improved glX error reporting.
+
 # Version 0.17.0 (2018-06-27)
 
 - Fix regression that prevented automatic graphics switching in MacOS ([#980](https://github.com/tomaka/glutin/issues/980))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,6 +526,8 @@ impl From<WindowCreationError> for CreationError {
 /// Error that can happen when manipulating an OpenGL context.
 #[derive(Debug)]
 pub enum ContextError {
+    /// General platform error.
+    OsError(String),
     IoError(io::Error),
     ContextLost,
 }
@@ -534,6 +536,7 @@ impl ContextError {
     fn to_string(&self) -> &str {
         use std::error::Error;
         match *self {
+            ContextError::OsError(ref string) => string,
             ContextError::IoError(ref err) => err.description(),
             ContextError::ContextLost => "Context lost"
         }


### PR DESCRIPTION
- Added a null pointer check when querying the glX extension list
- Added an `OsError` variant to `ContextError`, and used it to report errors that X11 tells us about