### PR TITLE
iOS: create the GLKView in glutin instead of inside winit

### DIFF
--- a/src/api/ios/ffi.rs
+++ b/src/api/ios/ffi.rs
@@ -2,6 +2,7 @@
 
 use std::os::raw::*;
 
+use objc::{Encode, Encoding};
 use objc::runtime::Object;
 
 pub mod gles {
@@ -10,6 +11,9 @@ pub mod gles {
 
 pub type id = *mut Object;
 pub const nil: id = 0 as id;
+
+pub const UIViewAutoresizingFlexibleWidth: NSUInteger = 1 << 1;
+pub const UIViewAutoresizingFlexibleHeight: NSUInteger = 1 << 4;
 
 #[cfg(target_pointer_width = "32")]
 pub type CGFloat = f32;
@@ -33,6 +37,19 @@ pub struct CGPoint {
 pub struct CGRect {
     pub origin: CGPoint,
     pub size: CGSize,
+}
+
+unsafe impl Encode for CGRect {
+    fn encode() -> Encoding {
+        #[cfg(target_pointer_width = "32")]
+        unsafe {
+            Encoding::from_str("{CGRect={CGPoint=ff}{CGSize=ff}}")
+        }
+        #[cfg(target_pointer_width = "64")]
+        unsafe {
+            Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}")
+        }
+    }
 }
 
 #[repr(C)]

--- a/src/os/ios.rs
+++ b/src/os/ios.rs
@@ -1,3 +1,3 @@
 #![cfg(target_os = "ios")]
 
-pub use winit::os::ios::{MonitorIdExt, WindowExt};
+pub use winit::os::ios::{MonitorIdExt, WindowExt, WindowBuilderExt};


### PR DESCRIPTION
This fixes `glutin` on `iOS` after this PR https://github.com/tomaka/winit/pull/609 .

It should not be merged until the next `winit` version is published.

The key change here is that `glutin` calls `WindowBuilderExt::with_root_view_class` passing in an objective-c class derived from `GLKView`. I didn't see this pattern on other platforms, so perhaps there's a better way to arrange things.