### PR TITLE
Update winit to 0.17.0 (#1055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Breaking:** Added `OsError` variant to `ContextError`.
 - Improved glX error reporting.
 - The iOS backend no longer fails to compile... again (added iOS testing on CI to prevent further issues).
+- Update winit dependency to 0.17.0. See [winit's CHANGELOG](https://github.com/tomaka/winit/blob/v0.17.0/CHANGELOG.md#version-0170-2018-08-02) for more info.
 
 # Version 0.17.0 (2018-06-27)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ icon_loading = ["winit/icon_loading"]
 lazy_static = "1"
 libc = "0.2"
 shared_library = "0.1.0"
-winit = "0.16.0"
+winit = "0.17.0"
 
 [build-dependencies]
 gl_generator = "0.9"


### PR DESCRIPTION
That seems to work fine.

Tested on macOS 10.13.6 with the following commands:

    cargo test
    cargo run --example window
    cargo run --example fullscreen
    cargo run --example transparent  # ❤️ that one
    cargo run --example multiwindow