### PR TITLE
Wayland: make libEGL loading behaviour consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - ***Breaking*** The entire API for headless contexts has been removed. Please instead use `Context::new()` when trying to make a context without a visible window. Also removed `headless` feature.
 - ***Breaking*** Types implementing the `GlContext` trait must now be sized.
 - ***Breaking*** Added new `CreationErrorPair` enum variant to enum `CreationError`.
+- Remove requirement for EGL dev packages on wayland.
 
 # Version 0.18.0 (2018-08-03)
 

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -26,7 +26,10 @@ impl Context {
         let surface = window.get_wayland_surface().unwrap();
         let egl_surface = unsafe { wegl::WlEglSurface::new_from_raw(surface as *mut _, w as i32, h as i32) };
         let context = {
-            let libegl = unsafe { dlopen::dlopen(b"libEGL.so\0".as_ptr() as *const _, dlopen::RTLD_NOW) };
+            let mut libegl = unsafe { dlopen::dlopen(b"libEGL.so.1\0".as_ptr() as *const _, dlopen::RTLD_NOW) };
+            if libegl.is_null() {
+                libegl = unsafe { dlopen::dlopen(b"libEGL.so\0".as_ptr() as *const _, dlopen::RTLD_NOW) };
+            }
             if libegl.is_null() {
                 return Err(CreationError::NotSupported("could not find libEGL"));
             }


### PR DESCRIPTION
The x11 implementation will try to load libEGL.so if so.1 is not
available but the wayland one didn't and so either required the user to
create the sym link themselves or install the devel packages which did
it for them.

This resolves the latter issues faced in #949 