### PR TITLE
Support NetBSD platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added NetBSD support.
+
 # Version 0.19.0 (2018-11-09)
 
 - **Breaking:** The entire API for headless contexts has been removed. Please instead use `Context::new()` when trying to make a context without a visible window. Also removed `headless` feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ features = [
     "libloaderapi",
 ]
 
-[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="openbsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="netbsd", target_os="openbsd"))'.dependencies]
 osmesa-sys = "0.1.0"
 wayland-client = { version = "0.21", features = ["egl", "dlopen"] }
 x11-dl = "2.18.3"

--- a/build.rs
+++ b/build.rs
@@ -53,7 +53,7 @@ fn main() {
             .write_bindings(gl_generator::StructGenerator, &mut file).unwrap();
     }
 
-    if target.contains("linux") || target.contains("dragonfly") || target.contains("freebsd") || target.contains("openbsd") {
+    if target.contains("linux") || target.contains("dragonfly") || target.contains("freebsd") || target.contains("netbsd") || target.contains("openbsd") {
         let mut file = File::create(&dest.join("glx_bindings.rs")).unwrap();
         Registry::new(Api::Glx, (1, 4), Profile::Core, Fallbacks::All, [])
             .write_bindings(gl_generator::StructGenerator, &mut file).unwrap();

--- a/src/api/caca/mod.rs
+++ b/src/api/caca/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 #![allow(unused_variables, dead_code)]
 
 use libc;

--- a/src/api/dlopen.rs
+++ b/src/api/dlopen.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 #![allow(dead_code)]
 
 use std::os::raw::{c_void, c_char, c_int};

--- a/src/api/egl/ffi.rs
+++ b/src/api/egl/ffi.rs
@@ -35,5 +35,5 @@ pub type EGLNativeWindowType = winapi::shared::windef::HWND;
 pub type EGLNativeWindowType = *const libc::c_void;
 #[cfg(target_os = "android")]
 pub type EGLNativeWindowType = *const libc::c_void;
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 pub type EGLNativeWindowType = *const libc::c_void;

--- a/src/api/egl/mod.rs
+++ b/src/api/egl/mod.rs
@@ -1,5 +1,6 @@
 #![cfg(any(target_os = "windows", target_os = "linux", target_os = "android",
-           target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+           target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd",
+           target_os = "openbsd"))]
 #![allow(unused_variables)]
 
 use ContextError;

--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 
 use {
     Api,

--- a/src/api/osmesa/mod.rs
+++ b/src/api/osmesa/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 
 extern crate osmesa_sys;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 #[macro_use]
 extern crate shared_library;
 
@@ -51,9 +51,9 @@ extern crate cocoa;
 extern crate core_foundation;
 #[cfg(target_os = "macos")]
 extern crate core_graphics;
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))]
 extern crate x11_dl;
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))]
 extern crate wayland_client;
 
 pub use winit::{

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 
 pub use api::egl::ffi::EGLContext;
 pub use api::glx::ffi::GLXContext;

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 
 use {ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements};
 use api::egl;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -3,7 +3,7 @@ pub use self::platform::*;
 #[cfg(target_os = "windows")]
 #[path="windows/mod.rs"]
 mod platform;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 #[path="linux/mod.rs"]
 mod platform;
 #[cfg(target_os = "macos")]
@@ -21,5 +21,6 @@ mod platform;
 
 #[cfg(all(not(target_os = "ios"), not(target_os = "windows"), not(target_os = "linux"),
   not(target_os = "macos"), not(target_os = "android"), not(target_os = "dragonfly"),
-  not(target_os = "freebsd"), not(target_os = "openbsd"), not(target_os = "emscripten")))]
+  not(target_os = "freebsd"), not(target_os = "netbsd"), not(target_os = "openbsd"),
+  not(target_os = "emscripten")))]
 use this_platform_is_not_supported;


### PR DESCRIPTION
Test result on NetBSD 8 with Rust 1.30.1.

```
$ cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running target/debug/deps/glutin-6ed9fca4d308c846

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests glutin

running 6 tests
test target/debug/build/glutin-6e1f9d8f4241066e/out/egl_bindings.rs - api::egl::ffi::egl::Egl::load_with (line 375) ...
ignored
test target/debug/build/glutin-6e1f9d8f4241066e/out/glx_bindings.rs - api::glx::ffi::glx::Glx::load_with (line 425) ...
ignored
test target/debug/build/glutin-6e1f9d8f4241066e/out/glx_extra_bindings.rs - api::glx::ffi::glx_extra::Glx::load_with (line 451) ... ignored
test src/lib.rs - GlWindow (line 153) ... ok
test src/lib.rs - Context (line 123) ... ok
test src/lib.rs -  (line 9) ... ok

test result: ok. 3 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
```