### PR TITLE
Increase MSRV to 1.28.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           packages: *i686_packages
     - env: TARGET=i686-unknown-linux-gnu
       os: linux
-      rust: 1.24.1
+      rust: 1.28.0
       addons:
         apt:
           packages: *i686_packages
@@ -35,7 +35,7 @@ matrix:
       rust: stable
     - env: TARGET=x86_64-unknown-linux-gnu
       os: linux
-      rust: 1.24.1
+      rust: 1.28.0
 
     # macOS
     - env: TARGET=x86_64-apple-darwin
@@ -46,7 +46,7 @@ matrix:
       rust: stable
     - env: TARGET=x86_64-apple-darwin
       os: osx
-      rust: 1.24.1
+      rust: 1.28.0
 
     # iOS
     - env: TARGET=x86_64-apple-ios
@@ -57,7 +57,7 @@ matrix:
       rust: stable
     - env: TARGET=x86_64-apple-ios
       os: osx
-      rust: 1.24.1
+      rust: 1.28.0
 
 addons:
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Version 0.19.0 (2018-11-09)
 
+- **Breaking:** minimum supported Rust version increased to 1.28.0.
 - **Breaking:** The entire API for headless contexts has been removed. Please instead use `Context::new()` when trying to make a context without a visible window. Also removed `headless` feature.
 - **Breaking:** Types implementing the `GlContext` trait must now be sized.
 - **Breaking:** Added new `CreationErrorPair` enum variant to enum `CreationError`.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ fn main() {
 
 Note that glutin aims at being a low-level brick in your rendering infrastructure. You are encouraged to write another layer of abstraction between glutin and your application.
 
+Also note that glutin requires Rust 1.28.0 or later.
+
 ## Platform-specific notes
 
 ### Android

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
     CHANNEL: stable
   - TARGET: x86_64-pc-windows-msvc
-    CHANNEL: 1.24.1
+    CHANNEL: 1.28.0
   - TARGET: i686-pc-windows-msvc
     CHANNEL: nightly
   - TARGET: i686-pc-windows-gnu


### PR DESCRIPTION
This is a follow-up to tomaka/winit#716.

The way the CHANGELOG is handled here looks pretty weird, but it's because we found out that our compatibility guarantees were retroactively broken (tomaka/winit#698).