### PR TITLE
Make `NoBackendAvailable` `Sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `build` method to `ContextBuilder`.
 - Added `get_egl_display` method to `GlContextExt` trait and its implementation for platforms.
 - Removed minimum supported Rust version guarantee.
+- `NoBackendAvailable` is now `Sync`, as a result `CreationError` is also `Sync`.
 
 # Version 0.19.0 (2018-11-09)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,7 +490,7 @@ pub enum CreationError {
     OsError(String),
     /// TODO: remove this error
     NotSupported(&'static str),
-    NoBackendAvailable(Box<std::error::Error + Send>),
+    NoBackendAvailable(Box<std::error::Error + Send + Sync>),
     RobustnessNotSupported,
     OpenGlVersionNotSupported,
     NoAvailablePixelFormat,


### PR DESCRIPTION
Is there anything that prevents this error from being `Sync` when it is boxed? I was wondering whether there was some reason I'm not aware of/totally misunderstanding for it.

For full context of why I'd need it to be sync https://github.com/ggez/ggez/issues/566