### PR TITLE
macos: Fix `Context::is_current` incorrectly returning `false`

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -185,8 +185,8 @@ impl Context {
     pub fn is_current(&self) -> bool {
         unsafe {
             let context = match *self {
-                Context::WindowedContext(ref c) => &c.context,
-                Context::HeadlessContext(ref c) => &c.context,
+                Context::WindowedContext(ref c) => *c.context,
+                Context::HeadlessContext(ref c) => *c.context,
             };
 
             let pool = NSAutoreleasePool::new(nil);


### PR DESCRIPTION
The title says everything.

This fixes the issue <https://github.com/glium/glium/issues/1721> in the downstream library, which has been caused by an assertion failure due to the incorrectly implemented `Context::is_current`.
