### PR TITLE
compare OpenGL contexts with == instead of isEqual

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -191,12 +191,7 @@ impl Context {
 
             let pool = NSAutoreleasePool::new(nil);
             let current = NSOpenGLContext::currentContext(nil);
-            let res = if current != nil {
-                let is_equal: BOOL = msg_send![current, isEqual: context];
-                is_equal != NO
-            } else {
-                false
-            };
+            let res = current == **context;
             let _: () = msg_send![pool, release];
             res
         }


### PR DESCRIPTION
I don't entirely understand why, but starting with a recent update to macOS, `is_current` has started returning false even when the OpenGL context is in fact current, tripping [this assert](https://github.com/glium/glium/blob/62d287fc9715ab0e10892da5237b478e5322fcaa/src/context/mod.rs#L647) in Glium (see [this issue](https://github.com/maps4print/azul/issues/73); I experienced it in a project I was working on as well). However, this seemed to fix it.