### PR TITLE
Attempt to implement context sharing on Mac

### DIFF
--- a/glutin/src/platform/macos/mod.rs
+++ b/glutin/src/platform/macos/mod.rs
@@ -60,16 +60,7 @@ impl Context {
         let transparent = wb.window.transparent;
         let win = wb.build(el)?;
 
-        let share_ctx = match gl_attr.sharing {
-            Some(outer) => {
-                let inner = match outer {
-                    Context::WindowedContext(w) => w.context.clone(),
-                    Context::HeadlessContext(h) => h.context.clone(),
-                };
-                *inner
-            }
-            None => nil,
-        };
+        let share_ctx = gl_attr.sharing.map_or(nil, |c| *c.get_id());
 
         match gl_attr.robustness {
             Robustness::RobustNoResetNotification
@@ -300,6 +291,14 @@ impl Context {
         match *self {
             Context::WindowedContext(ref c) => *c.context.deref() as *mut _,
             Context::HeadlessContext(ref c) => *c.context.deref() as *mut _,
+        }
+    }
+
+    #[inline]
+    fn get_id(&self) -> IdRef {
+        match self {
+            Context::WindowedContext(w) => w.context.clone(),
+            Context::HeadlessContext(h) => h.context.clone(),
         }
     }
 }


### PR DESCRIPTION
I have no idea if this is the right thing to do or not, but with this patch I can run the sharing example.

I've never done any cocoa programming at all; I just followed the "Sharing Rendering Context Resources" section of https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_contexts/opengl_contexts.html and did what seemed obvious, and I was surprised that it actually seemed to work.

I don't have another platform to run the examples on right now to actually check if the sharing example renders identically compared to other platforms.

This will contribute to tomaka/glutin#899