### PR TITLE
iOS: Fix UB in `Context::create_context`

### DIFF
--- a/glutin/src/api/ios/mod.rs
+++ b/glutin/src/api/ios/mod.rs
@@ -219,13 +219,13 @@ impl Context {
 
     unsafe fn create_context(mut version: ffi::NSUInteger) -> Result<ffi::id, CreationError> {
         let context_class = Class::get("EAGLContext").expect("Failed to get class `EAGLContext`");
-        let eagl_context: ffi::id = msg_send![context_class, alloc];
-        let mut valid_context = ffi::nil;
-        while valid_context == ffi::nil && version > 0 {
-            valid_context = msg_send![eagl_context, initWithAPI: version];
+        let mut eagl_context: ffi::id = ffi::nil;
+        while eagl_context.is_null() && version > 0 {
+            eagl_context = msg_send![context_class, alloc];
+            eagl_context = msg_send![eagl_context, initWithAPI: version];
             version -= 1;
         }
-        if valid_context == ffi::nil {
+        if eagl_context.is_null() {
             Err(CreationError::OsError(
                 "Failed to create an OpenGL ES context with any version".to_string(),
             ))


### PR DESCRIPTION
We were calling an `init` method on the same object multiple times, which is not allowed in Objective-C.

Found while making #1440. With this change I can now run `glutin` on my old iPad.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
