### PR TITLE
egl: support grabbing current context and display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bump MSRV from `1.71` to `1.85`.
 - Fixed EGL's robustness detection without extension, but on EGL 1.5.
 - Added `PossibilityCurrentContext::current` and `Display::current` for EGL
+- `RawContext` now implements `AsRawContext`
 
 # Version 0.32.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Use `objc2-open-gl` instead of `cgl` dependency.
 - Bump MSRV from `1.71` to `1.85`.
 - Fixed EGL's robustness detection without extension, but on EGL 1.5.
+- Added `PossibilityCurrentContext::current` and `Display::current` for EGL
 
 # Version 0.32.3
 

--- a/glutin/src/api/egl/config.rs
+++ b/glutin/src/api/egl/config.rs
@@ -229,6 +229,10 @@ pub struct Config {
 }
 
 impl Config {
+    pub(crate) fn from_raw(display: Display, raw: EGLConfig) -> Self {
+        Self { inner: Arc::new(ConfigInner { display, raw: EglConfig(raw) }) }
+    }
+
     /// The native visual identifier.
     ///
     /// The interpretation of this value is platform dependant. Consult

--- a/glutin/src/context.rs
+++ b/glutin/src/context.rs
@@ -149,6 +149,12 @@ pub trait AsRawContext {
     fn raw_context(&self) -> RawContext;
 }
 
+impl AsRawContext for RawContext {
+    fn raw_context(&self) -> RawContext {
+        *self
+    }
+}
+
 /// The builder to help customizing context
 #[derive(Default, Debug, Clone)]
 pub struct ContextAttributesBuilder {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Open questions:
- I'm not sure about the error handling when grabbing the current context.
- I'm also not sure about the error handling when parsing the Display version, though it seems like it'd be a driver bug for that to fail.