### PR TITLE
Use `doc_cfg` instead of `doc_auto_cfg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Use `objc2-open-gl` instead of `cgl` dependency.
 - Bump MSRV from `1.71` to `1.85`.
 - Fixed EGL's robustness detection without extension, but on EGL 1.5.
+- Fixed building docs on docs.rs.
 
 # Version 0.32.3
 

--- a/glutin/src/lib.rs
+++ b/glutin/src/lib.rs
@@ -21,7 +21,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![cfg_attr(clippy, deny(warnings))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(not(egl_backend), not(glx_backend), not(wgl_backend), not(cgl_backend)))]
 compile_error!("Please select at least one api backend");


### PR DESCRIPTION
Building on docs.rs is gonna fail the next time we release if we don't update this.