### PR TITLE
fix(wgl): handle unreliable WGL_TRANSPARENT_ARB by returning None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bump MSRV from `1.71` to `1.85`.
 - Fixed EGL's robustness detection without extension, but on EGL 1.5.
 - Fixed building docs on docs.rs.
+- Fixed WGL's unreliable TRANSPARENT_ARB false negatives by returning None
 
 # Version 0.32.3
 

--- a/glutin/src/api/wgl/config.rs
+++ b/glutin/src/api/wgl/config.rs
@@ -448,9 +448,10 @@ impl GlConfig for Config {
             // WGL_TRANSPARENT_ARB is not reliable and can sometimes produce false
             // negatives. return None to provide consistent semantics, since we
             // don't have any better way to detect
-            let transparent =
-                unsafe { self.raw_attribute(wgl_extra::TRANSPARENT_ARB as c_int) != 0 };
-            transparent.then_some(true)
+            match unsafe { self.raw_attribute(wgl_extra::TRANSPARENT_ARB as c_int) } {
+                1 => Some(true),
+                _ => None,
+            }
         }
     }
 

--- a/glutin/src/api/wgl/config.rs
+++ b/glutin/src/api/wgl/config.rs
@@ -445,7 +445,12 @@ impl GlConfig for Config {
         if self.inner.descriptor.as_ref().is_some() {
             None
         } else {
-            unsafe { Some(self.raw_attribute(wgl_extra::TRANSPARENT_ARB as c_int) != 0) }
+            // WGL_TRANSPARENT_ARB is not reliable and can sometimes produce false
+            // negatives. return None to provide consistent semantics, since we
+            // don't have any better way to detect
+            let transparent =
+                unsafe { self.raw_attribute(wgl_extra::TRANSPARENT_ARB as c_int) != 0 };
+            transparent.then_some(true)
         }
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Fixes #1717 

### Why

`WGL_TRANSPARENT_ARB` is unreliable and can return false negatives, leading to incorrect false results.
e.g. https://github.com/GPUOpen-Drivers/AMD-Gfx-Drivers/issues/29

### How

Return `None` instead of `Some(false)` when transparency can’t be determined reliably, providing consistent semantics and avoiding misleading results.


