### PR TITLE
Allow skipping pixel-format OpenGL profile attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fixed EGL's robustness detection without extension, but on EGL 1.5.
 - Fixed building docs on docs.rs.
 - Fixed WGL's unreliable TRANSPARENT_ARB false negatives by returning None
+- Added `ConfigTemplateBuilder::skip_cgl_profile` to allow skipping CGL's `NSOpenGLProfile`
+  (allowing an older openGL version with extensions to work on macOS).
 
 # Version 0.32.3
 

--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -95,24 +95,30 @@ impl Display {
             attrs.push(NSOpenGLPFAStereo);
         }
 
-        // Skip `NSOpenGLPFAOpenGLProfile` when configured.
-        let profile_attrs = if template.skip_cgl_profile {
-            vec![[0u32, 0u32]]
+        let base_len = attrs.len();
+
+        // When `skip_cgl_profile` is set, skip profile selection entirely (None only).
+        // Otherwise try each profile in order, falling back to no profile on failure.
+        let profiles: &[Option<(_, _)>] = if template.skip_cgl_profile {
+            &[None]
         } else {
-            vec![
-                // Automatically pick the latest profile. If all profiles fail,
-                // skip profile selection.
-                [NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion4_1Core],
-                [NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core],
-                [NSOpenGLPFAOpenGLProfile,  NSOpenGLProfileVersionLegacy],
-                [                       0,                             0],
+            &[
+                Some((NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion4_1Core)),
+                Some((NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core)),
+                Some((NSOpenGLPFAOpenGLProfile,  NSOpenGLProfileVersionLegacy)),
+                None,
             ]
         };
 
-        let raw = profile_attrs
+        let raw = profiles
             .into_iter()
             .find_map(|profile| {
-                let attrs: Vec<_> = attrs.iter().chain(profile.iter()).copied().collect();
+                attrs.truncate(base_len);
+                if let Some((key, val)) = profile {
+                    attrs.push(*key);
+                    attrs.push(*val);
+                }
+                attrs.push(0); // null terminator
                 // initWithAttributes returns None if the attributes were invalid
                 unsafe {
                     NSOpenGLPixelFormat::initWithAttributes(

--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -95,34 +95,33 @@ impl Display {
             attrs.push(NSOpenGLPFAStereo);
         }
 
-        attrs.push(NSOpenGLPFAOpenGLProfile);
+        // Skip `NSOpenGLPFAOpenGLProfile` when configured.
+        let profile_attrs = if template.skip_cgl_profile {
+            vec![[0u32, 0u32]]
+        } else {
+            vec![
+                // Automatically pick the latest profile. If all profiles fail,
+                // skip profile selection.
+                [NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion4_1Core],
+                [NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core],
+                [NSOpenGLPFAOpenGLProfile,  NSOpenGLProfileVersionLegacy],
+                [                       0,                             0],
+            ]
+        };
 
-        // Stash profile pos for latter insert.
-        let profile_attr_pos = attrs.len();
-        // Add place holder for the GL profile.
-        attrs.push(NSOpenGLProfileVersion4_1Core);
-
-        // Terminate attrs with zero.
-        attrs.push(0);
-
-        // Automatically pick the latest profile.
-        let raw = [
-            NSOpenGLProfileVersion4_1Core,
-            NSOpenGLProfileVersion3_2Core,
-            NSOpenGLProfileVersionLegacy,
-        ]
-        .into_iter()
-        .find_map(|profile| {
-            attrs[profile_attr_pos] = profile;
-            // initWithAttributes returns None if the attributes were invalid
-            unsafe {
-                NSOpenGLPixelFormat::initWithAttributes(
-                    <NSOpenGLPixelFormat as AllocAnyThread>::alloc(),
-                    NonNull::new(attrs.as_ptr().cast_mut()).unwrap(),
-                )
-            }
-        })
-        .ok_or(ErrorKind::BadConfig)?;
+        let raw = profile_attrs
+            .into_iter()
+            .find_map(|profile| {
+                let attrs: Vec<_> = attrs.iter().chain(profile.iter()).copied().collect();
+                // initWithAttributes returns None if the attributes were invalid
+                unsafe {
+                    NSOpenGLPixelFormat::initWithAttributes(
+                        <NSOpenGLPixelFormat as AllocAnyThread>::alloc(),
+                        NonNull::new(attrs.as_ptr().cast_mut()).unwrap(),
+                    )
+                }
+            })
+            .ok_or(ErrorKind::BadConfig)?;
 
         let inner = Arc::new(ConfigInner {
             display: self.clone(),

--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -111,7 +111,7 @@ impl Display {
         };
 
         let raw = profiles
-            .into_iter()
+            .iter()
             .find_map(|profile| {
                 attrs.truncate(base_len);
                 if let Some((key, val)) = profile {

--- a/glutin/src/api/cgl/config.rs
+++ b/glutin/src/api/cgl/config.rs
@@ -105,7 +105,7 @@ impl Display {
             &[
                 Some((NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion4_1Core)),
                 Some((NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core)),
-                Some((NSOpenGLPFAOpenGLProfile,  NSOpenGLProfileVersionLegacy)),
+                Some((NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersionLegacy)),
                 None,
             ]
         };

--- a/glutin/src/config.rs
+++ b/glutin/src/config.rs
@@ -266,9 +266,9 @@ impl ConfigTemplateBuilder {
     /// Request that the `NSOpenGLProfile` selection is skipped on `CGL/macOS`.
     /// This allows better compatibility with older openGL profiles
     /// that rely on certain OpenGL extensions (from newer versions).
-    /// 
+    ///
     /// # Api-specific
-    /// 
+    ///
     /// Only supported with `CGL` (`macOS`)
     #[inline]
     pub fn skip_cgl_profile(mut self, skip: bool) -> Self {
@@ -377,7 +377,7 @@ impl Default for ConfigTemplate {
 
             api: None,
 
-            skip_cgl_profile: false
+            skip_cgl_profile: false,
         }
     }
 }

--- a/glutin/src/config.rs
+++ b/glutin/src/config.rs
@@ -263,6 +263,19 @@ impl ConfigTemplateBuilder {
         self
     }
 
+    /// Request that the `NSOpenGLProfile` selection is skipped on `CGL/macOS`.
+    /// This allows better compatibility with older openGL profiles
+    /// that rely on certain OpenGL extensions (from newer versions).
+    /// 
+    /// # Api-specific
+    /// 
+    /// Only supported with `CGL` (`macOS`)
+    #[inline]
+    pub fn skip_cgl_profile(mut self, skip: bool) -> Self {
+        self.template.skip_cgl_profile = skip;
+        self
+    }
+
     /// Build the template to match the configs against.
     #[must_use]
     pub fn build(self) -> ConfigTemplate {
@@ -323,6 +336,10 @@ pub struct ConfigTemplate {
 
     /// The native window config should support rendering into.
     pub(crate) native_window: Option<RawWindowHandle>,
+
+    /// Only has effect on `CGL/macOS`.
+    /// Skips`NSOpenGLProfile` attributes to the pixel format configuration.
+    pub(crate) skip_cgl_profile: bool,
 }
 
 impl Default for ConfigTemplate {
@@ -359,6 +376,8 @@ impl Default for ConfigTemplate {
             hardware_accelerated: None,
 
             api: None,
+
+            skip_cgl_profile: false
         }
     }
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] ~~Created or updated an example program if it would help users understand this functionality~~

This is essentially the same as #1740 , with the exception of allowing configurable behavior and in being more compact. By default, nothing is changed to the previous behavior of `glutin` on macOS (CGL) except the added no-profile fallback when all prior profile selections fail.

Essentially, it addresses the problem of certain OpenGL extensions not working on macOS (`ARB_framebuffer_object`).

All the formatting errors are pre-existing.