### PR TITLE
Create weekly dependabot configuration for `cargo` and `github-actions`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/.github/workflows/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This configuration will let dependabot scan and suggest updates in both `Cargo.toml` as well as GitHub actions workflows.  `glutin` is a light crate with few dependencies so the volume of PRs will likely remain low, though it's a useful reminder in the odd case where an update does become available.

As discussed in https://github.com/rust-windowing/glutin/pull/1590#issuecomment-4857023573.
