### PR TITLE
Use `wayland-egl` crate instead of `wayland-sys`

### DIFF
--- a/glutin/Cargo.toml
+++ b/glutin/Cargo.toml
@@ -17,7 +17,7 @@ egl = ["glutin_egl_sys", "libloading"]
 glx = ["x11", "glutin_glx_sys", "libloading"]
 wgl = ["glutin_wgl_sys", "windows-sys"]
 x11 = ["x11-dl"]
-wayland = ["wayland-sys", "egl"]
+wayland = ["dep:wayland-egl", "egl"]
 
 [dependencies]
 bitflags = "2.2.1"
@@ -46,9 +46,8 @@ glutin_egl_sys = { version = "0.7.1", path = "../glutin_egl_sys" }
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 glutin_egl_sys = { version = "0.7.1", path = "../glutin_egl_sys", optional = true }
 glutin_glx_sys = { version = "0.6.1", path = "../glutin_glx_sys", optional = true }
-wayland-sys = { version = "0.31.1", default-features = false, features = [
-    "egl",
-    "client",
+# XXX Release
+wayland-egl = { git  = "https://github.com/smithay/wayland-rs", default-features = false, features = [
     "dlopen",
 ], optional = true }
 x11-dl = { version = "2.20.0", optional = true }

--- a/glutin/src/api/egl/surface.rs
+++ b/glutin/src/api/egl/surface.rs
@@ -8,7 +8,7 @@ use glutin_egl_sys::egl;
 use glutin_egl_sys::egl::types::{EGLAttrib, EGLSurface, EGLint};
 use raw_window_handle::RawWindowHandle;
 #[cfg(wayland_platform)]
-use wayland_sys::{egl::*, ffi_dispatch};
+use wayland_egl::WlEglSurface;
 
 use crate::api::egl::display::EglDisplay;
 use crate::config::GetGlConfig;
@@ -440,7 +440,7 @@ impl<T: SurfaceTypeTrait> Sealed for Surface<T> {}
 #[derive(Debug)]
 enum NativeWindow {
     #[allow(dead_code)]
-    Wayland(*mut ffi::c_void),
+    Wayland(WlEglSurface),
     Xlib(std::os::raw::c_ulong),
     Xcb(u32),
     Android(*mut ffi::c_void),
@@ -458,17 +458,13 @@ impl NativeWindow {
         let native_window = match raw_window_handle {
             #[cfg(wayland_platform)]
             RawWindowHandle::Wayland(window_handle) => unsafe {
-                let ptr = ffi_dispatch!(
-                    wayland_egl_handle(),
-                    wl_egl_window_create,
-                    window_handle.surface.as_ptr().cast(),
+                let surface = WlEglSurface::new_from_raw(
+                    window_handle.surface.cast(),
                     _width.get() as _,
-                    _height.get() as _
-                );
-                if ptr.is_null() {
-                    return Err(ErrorKind::OutOfMemory.into());
-                }
-                Self::Wayland(ptr.cast())
+                    _height.get() as _,
+                )
+                .unwrap();
+                Self::Wayland(surface)
             },
             RawWindowHandle::Xlib(window_handle) => {
                 if window_handle.window == 0 {
@@ -499,30 +495,20 @@ impl NativeWindow {
     fn resize(&self, _width: NonZeroU32, _height: NonZeroU32) {
         #[cfg(wayland_platform)]
         if let Self::Wayland(wl_egl_surface) = self {
-            unsafe {
-                ffi_dispatch!(
-                    wayland_egl_handle(),
-                    wl_egl_window_resize,
-                    *wl_egl_surface as _,
-                    _width.get() as _,
-                    _height.get() as _,
-                    0,
-                    0
-                )
-            }
+            wl_egl_surface.resize(_width.get() as _, _height.get() as _, 0, 0);
         }
     }
 
     /// Returns the underlying handle value.
     fn as_native_window(&self) -> egl::NativeWindowType {
-        match *self {
-            Self::Wayland(wl_egl_surface) => wl_egl_surface as egl::NativeWindowType,
-            Self::Xlib(window_id) => window_id as egl::NativeWindowType,
-            Self::Xcb(window_id) => window_id as egl::NativeWindowType,
-            Self::Win32(hwnd) => hwnd as egl::NativeWindowType,
-            Self::Android(a_native_window) => a_native_window as egl::NativeWindowType,
-            Self::Ohos(native_window) => native_window as egl::NativeWindowType,
-            Self::Gbm(gbm_surface) => gbm_surface as egl::NativeWindowType,
+        match self {
+            Self::Wayland(wl_egl_surface) => wl_egl_surface.ptr().as_ptr() as egl::NativeWindowType,
+            Self::Xlib(window_id) => *window_id as egl::NativeWindowType,
+            Self::Xcb(window_id) => *window_id as egl::NativeWindowType,
+            Self::Win32(hwnd) => *hwnd as egl::NativeWindowType,
+            Self::Android(a_native_window) => *a_native_window as egl::NativeWindowType,
+            Self::Ohos(native_window) => *native_window as egl::NativeWindowType,
+            Self::Gbm(gbm_surface) => *gbm_surface as egl::NativeWindowType,
         }
     }
 
@@ -542,24 +528,13 @@ impl NativeWindow {
     /// On X11 the returned pointer is a cast of the `&self` borrow.
     fn as_platform_window(&self) -> *mut ffi::c_void {
         match self {
-            Self::Wayland(wl_egl_surface) => *wl_egl_surface,
+            Self::Wayland(wl_egl_surface) => wl_egl_surface.ptr().as_ptr(),
             Self::Xlib(window_id) => window_id as *const _ as *mut ffi::c_void,
             Self::Xcb(window_id) => window_id as *const _ as *mut ffi::c_void,
             Self::Win32(hwnd) => *hwnd as *const ffi::c_void as *mut _,
             Self::Android(a_native_window) => *a_native_window,
             Self::Ohos(native_window) => *native_window,
             Self::Gbm(gbm_surface) => *gbm_surface,
-        }
-    }
-}
-
-#[cfg(wayland_platform)]
-impl Drop for NativeWindow {
-    fn drop(&mut self) {
-        unsafe {
-            if let Self::Wayland(wl_egl_window) = self {
-                ffi_dispatch!(wayland_egl_handle(), wl_egl_window_destroy, wl_egl_window.cast());
-            }
         }
     }
 }


### PR DESCRIPTION
This is a draft since it is currently based on the upcoming release of wayland-rs.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
